### PR TITLE
Add DHW (Domestic Hot Water) support via water_heater platform

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest pytest-asyncio==0.24.0
           pip install homeassistant==2024.3.3
-          pip install pysensorlinx==0.1.9
+          pip install pysensorlinx==0.2.1
 
       - name: Run tests
         run: python -m pytest tests/ -v --tb=short

--- a/custom_components/hbx_controls/__init__.py
+++ b/custom_components/hbx_controls/__init__.py
@@ -21,6 +21,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SWITCH,
     Platform.SELECT,
+    Platform.WATER_HEATER,
 ]
 
 

--- a/custom_components/hbx_controls/coordinator.py
+++ b/custom_components/hbx_controls/coordinator.py
@@ -283,6 +283,30 @@ class HBXControlsDataUpdateCoordinator(DataUpdateCoordinator):
                   except:
                     pass
                   
+                  # DHW (Domestic Hot Water)
+                  try:
+                    parameters["dhw_enabled"] = await device_helper.get_dhw_enabled(device_info=device)
+                  except:
+                    pass
+                  
+                  try:
+                    parameters["dhw_target_temp"] = await device_helper.get_dhw_target_temp(device_info=device)
+                  except:
+                    pass
+                  
+                  try:
+                    parameters["dhw_differential"] = await device_helper.get_dhw_differential(device_info=device)
+                  except:
+                    pass
+                  
+                  try:
+                    dhw_state = await device_helper.get_dhw_state(device_info=device)
+                    if dhw_state:
+                      parameters["dhw_state"] = dhw_state
+                      _LOGGER.debug("Device %s dhw_state: %s", device_id, dhw_state)
+                  except Exception as e:
+                    _LOGGER.debug("Failed to get dhw_state for device %s: %s", device_id, e)
+                  
                 except Exception as param_exc:
                   _LOGGER.warning("Failed to extract parameters for device %s: %s", device_id, param_exc)
                 

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
-  "requirements": ["pysensorlinx==0.1.9"],
+  "requirements": ["pysensorlinx==0.2.1"],
   "version": "2.2.0"
 }

--- a/custom_components/hbx_controls/number.py
+++ b/custom_components/hbx_controls/number.py
@@ -305,6 +305,17 @@ async def async_setup_entry(
                         building_id,
                     )
                 )
+
+            # DHW Differential
+            if "dhw_differential" in device_parameters:
+                entities.append(
+                    DHWDifferential(
+                        coordinator,
+                        device_id,
+                        device,
+                        building_id,
+                    )
+                )
     
     _LOGGER.debug("Adding %d number entities", len(entities))
     async_add_entities(entities)
@@ -2406,4 +2417,110 @@ class BackupOnlyTankTemp(CoordinatorEntity, NumberEntity):
         )
         temp = Temperature(value, "F")
         await device_helper.set_backup_only_tank_temp(temp)
+        await self.coordinator.async_request_refresh()
+
+
+class DHWDifferential(CoordinatorEntity, NumberEntity):
+    """DHW (Domestic Hot Water) Differential control.
+
+    Sets the desired DHW differential. For example, a differential of 4°F
+    will allow for 2 degrees above and/or 2 degrees below the desired
+    DHW temperature before a demand is present.
+    """
+
+    _attr_mode = NumberMode.BOX
+    _attr_icon = "mdi:thermometer-water"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: HBXControlsDataUpdateCoordinator,
+        device_id: str,
+        device: dict[str, Any],
+        building_id: str,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._device = device
+        self._building_id = building_id
+
+        self._attr_unique_id = f"{device_id}_dhw_differential"
+        self._attr_name = f"{device.get('name', device_id)} DHW Differential"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "name": device.get("name", device_id),
+            "manufacturer": "HBX Controls",
+            "model": device.get("deviceType", "Unknown"),
+            "sw_version": device.get("firmware_version"),
+        }
+
+    @property
+    def native_step(self) -> float:
+        """Return step value based on unit system."""
+        if self.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS:
+            return 0.1
+        return 1
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        """Return the unit of measurement based on HA config."""
+        if self.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS:
+            return UnitOfTemperature.CELSIUS
+        return UnitOfTemperature.FAHRENHEIT
+
+    @property
+    def native_min_value(self) -> float:
+        """Return minimum value based on unit system."""
+        if self.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS:
+            return 1.0  # 2°F ≈ 1.1°C, rounded to 1.0
+        return 2
+
+    @property
+    def native_max_value(self) -> float:
+        """Return maximum value based on unit system."""
+        if self.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS:
+            return 55.5  # 100°F ≈ 55.6°C, rounded to 55.5
+        return 100
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value."""
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return None
+        parameters = device.get("parameters", {})
+        value = parameters.get("dhw_differential")
+        if isinstance(value, TemperatureDelta):
+            if self.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS:
+                return round(value.to_celsius() * 2) / 2
+            return value.to_fahrenheit()
+        return value
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and "devices" in self.coordinator.data
+            and self._device_id in self.coordinator.data["devices"]
+            and "dhw_differential" in self.coordinator.data["devices"][self._device_id].get("parameters", {})
+        )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the DHW differential value."""
+        device_helper = SensorlinxDevice(
+            self.coordinator.sensorlinx,
+            self._building_id,
+            self._device_id,
+        )
+        if self.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS:
+            delta = TemperatureDelta(value, "C")
+        else:
+            delta = TemperatureDelta(value, "F")
+        await device_helper.set_dhw_differential(delta)
         await self.coordinator.async_request_refresh()

--- a/custom_components/hbx_controls/sensor.py
+++ b/custom_components/hbx_controls/sensor.py
@@ -137,6 +137,18 @@ async def async_setup_entry(
                         backup_title,
                     )
                 )
+            
+            # Create DHW state sensor
+            dhw_state = device_parameters.get("dhw_state")
+            if dhw_state:
+                _LOGGER.debug("Creating DHW state sensor for device %s", device_id)
+                entities.append(
+                    DHWStateSensor(
+                        coordinator,
+                        device_id,
+                        device,
+                    )
+                )
     else:
         _LOGGER.debug("No coordinator data or devices found")
     
@@ -338,3 +350,68 @@ class BackupRuntimeSensor(CoordinatorEntity, SensorEntity):
             
         parameters = device.get("parameters", {})
         return parameters.get("backup_state") is not None
+
+
+class DHWStateSensor(CoordinatorEntity, SensorEntity):
+    """Implementation of a DHW (Domestic Hot Water) state sensor."""
+
+    _attr_icon = "mdi:water-boiler"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: HBXControlsDataUpdateCoordinator,
+        device_id: str,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize the DHW state sensor."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._device = device
+
+        self._attr_unique_id = f"{device_id}_dhw_state"
+        self._attr_name = f"{device.get('name', device_id)} DHW State"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "name": device.get("name", device_id),
+            "manufacturer": "HBX Controls",
+            "model": device.get("type", "Unknown"),
+            "sw_version": device.get("firmware_version"),
+        }
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the DHW state as a string."""
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return None
+
+        parameters = device.get("parameters", {})
+        dhw_state = parameters.get("dhw_state")
+
+        if not dhw_state:
+            return None
+
+        return "Heating" if dhw_state.get("activated") else "Idle"
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        if not (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and "devices" in self.coordinator.data
+            and self._device_id in self.coordinator.data["devices"]
+        ):
+            return False
+
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return False
+
+        parameters = device.get("parameters", {})
+        return parameters.get("dhw_state") is not None

--- a/custom_components/hbx_controls/water_heater.py
+++ b/custom_components/hbx_controls/water_heater.py
@@ -1,0 +1,180 @@
+"""Platform for water_heater integration (DHW — Domestic Hot Water)."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pysensorlinx.sensorlinx import SensorlinxDevice, Temperature
+
+from homeassistant.components.water_heater import (
+    WaterHeaterEntity,
+    WaterHeaterEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import HBXControlsDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+STATE_HEATING = "heating"
+STATE_IDLE = "idle"
+
+OPERATION_LIST = [STATE_HEATING, STATE_IDLE]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the water heater platform."""
+    coordinator: HBXControlsDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = []
+
+    _LOGGER.debug("Setting up water heater platform")
+
+    if coordinator.data and "devices" in coordinator.data:
+        devices = coordinator.data["devices"]
+
+        for device_id, device in devices.items():
+            device_parameters = device.get("parameters", {})
+            building_id = device.get("building_id")
+
+            if "dhw_enabled" in device_parameters:
+                entities.append(
+                    HBXDHWWaterHeater(
+                        coordinator,
+                        device_id,
+                        device,
+                        building_id,
+                    )
+                )
+
+    _LOGGER.debug("Adding %d water heater entities", len(entities))
+    async_add_entities(entities)
+
+
+class HBXDHWWaterHeater(CoordinatorEntity, WaterHeaterEntity):
+    """Water heater entity for HBX DHW (Domestic Hot Water) control."""
+
+    _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
+    _attr_min_temp = 33
+    _attr_max_temp = 180
+    _attr_operation_list = OPERATION_LIST
+    _attr_supported_features = (
+        WaterHeaterEntityFeature.TARGET_TEMPERATURE
+        | WaterHeaterEntityFeature.ON_OFF
+    )
+    _attr_icon = "mdi:water-boiler"
+
+    def __init__(
+        self,
+        coordinator: HBXControlsDataUpdateCoordinator,
+        device_id: str,
+        device: dict[str, Any],
+        building_id: str,
+    ) -> None:
+        """Initialize the water heater entity."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._device = device
+        self._building_id = building_id
+
+        self._attr_unique_id = f"{device_id}_dhw"
+        self._attr_name = f"{device.get('name', device_id)} DHW"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "name": device.get("name", device_id),
+            "manufacturer": "HBX Controls",
+            "model": device.get("deviceType", "Unknown"),
+            "sw_version": device.get("firmware_version"),
+        }
+
+    @property
+    def current_operation(self) -> str | None:
+        """Return the current DHW operation (heating or idle)."""
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return None
+        parameters = device.get("parameters", {})
+        dhw_state = parameters.get("dhw_state")
+        if not dhw_state:
+            return None
+        return STATE_HEATING if dhw_state.get("activated") else STATE_IDLE
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the DHW target temperature."""
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return None
+        parameters = device.get("parameters", {})
+        temp = parameters.get("dhw_target_temp")
+        if temp is None:
+            return None
+        return temp.value if hasattr(temp, "value") else temp
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if DHW is enabled."""
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return None
+        parameters = device.get("parameters", {})
+        return parameters.get("dhw_enabled")
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and "devices" in self.coordinator.data
+            and self._device_id in self.coordinator.data["devices"]
+        )
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set the DHW target temperature."""
+        temperature = kwargs.get("temperature")
+        if temperature is None:
+            return
+        device_helper = SensorlinxDevice(
+            self.coordinator.sensorlinx,
+            self._building_id,
+            self._device_id,
+        )
+        await device_helper.set_dhw_target_temp(Temperature(temperature, "F"))
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on DHW."""
+        device_helper = SensorlinxDevice(
+            self.coordinator.sensorlinx,
+            self._building_id,
+            self._device_id,
+        )
+        await device_helper.set_dhw_enabled(True)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off DHW."""
+        device_helper = SensorlinxDevice(
+            self.coordinator.sensorlinx,
+            self._building_id,
+            self._device_id,
+        )
+        await device_helper.set_dhw_enabled(False)
+        await self.coordinator.async_request_refresh()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pysensorlinx==0.1.9
+pysensorlinx==0.2.1
 homeassistant>=2023.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,10 @@ def make_full_parameters(
     two_stage_heat_pump: bool = False,
     heat_cool_switch_delay: int = 60,
     backup_only_tank_temp: Any = "off",
+    dhw_enabled: bool | object = _UNSET,
+    dhw_target_temp: Any | object = _UNSET,
+    dhw_differential: Any | object = _UNSET,
+    dhw_state: dict | None | object = _UNSET,
 ) -> dict[str, Any]:
     """Build a complete set of device parameters for testing."""
     if heatpump_stages is _UNSET:
@@ -140,7 +144,25 @@ def make_full_parameters(
     if backup_state is _UNSET:
         backup_state = {"title": "Backup", "activated": False, "runTime": "10:00:00"}
 
-    return {
+    if dhw_enabled is _UNSET:
+        dhw_enabled = True
+
+    if dhw_target_temp is _UNSET:
+        from unittest.mock import MagicMock
+        dhw_target_temp = MagicMock()
+        dhw_target_temp.value = 120.0
+
+    if dhw_differential is _UNSET:
+        from unittest.mock import MagicMock as _MM
+        dhw_differential = _MM()
+        dhw_differential.value = 10.0
+        dhw_differential.to_fahrenheit = lambda: 10.0
+        dhw_differential.to_celsius = lambda: 5.6
+
+    if dhw_state is _UNSET:
+        dhw_state = {"activated": False, "enabled": True, "title": "DHW"}
+
+    params = {
         "temperature_tank": temperature_tank,
         "target_temperature_tank": target_temperature_tank,
         "temperature_outdoor": temperature_outdoor,
@@ -177,6 +199,18 @@ def make_full_parameters(
         "heat_cool_switch_delay": heat_cool_switch_delay,
         "backup_only_tank_temp": backup_only_tank_temp,
     }
+
+    # DHW parameters — only included when not None
+    if dhw_enabled is not None:
+        params["dhw_enabled"] = dhw_enabled
+    if dhw_target_temp is not None:
+        params["dhw_target_temp"] = dhw_target_temp
+    if dhw_differential is not None:
+        params["dhw_differential"] = dhw_differential
+    if dhw_state is not None:
+        params["dhw_state"] = dhw_state
+
+    return params
 
 
 def make_coordinator_data(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -60,7 +60,8 @@ async def test_platforms_list():
     assert Platform.NUMBER in PLATFORMS
     assert Platform.SWITCH in PLATFORMS
     assert Platform.SELECT in PLATFORMS
-    assert len(PLATFORMS) == 6
+    assert Platform.WATER_HEATER in PLATFORMS
+    assert len(PLATFORMS) == 7
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -80,8 +80,8 @@ async def test_setup_creates_number_entities(
     #  rotate cycles, rotate time, backup lag, backup diff,
     #  hot tank diff, cold tank diff, backup only outdoor,
     #  num stages, backup temp, weather shutdown lag, heat/cool switch delay,
-    #  backup only tank temp)
-    assert len(entities) == 24
+    #  backup only tank temp, dhw differential)
+    assert len(entities) == 25
 
 
 async def test_setup_no_data(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -45,7 +45,8 @@ async def test_setup_creates_all_sensors(
     # 5 SENSOR_DESCRIPTIONS (tank temp, target temp, outdoor temp, firmware, device type)
     # + 2 heat pump stage runtime sensors
     # + 1 backup runtime sensor
-    assert len(entities) == 8
+    # + 1 DHW state sensor
+    assert len(entities) == 9
 
 
 async def test_setup_no_data(
@@ -74,8 +75,8 @@ async def test_setup_no_heatpump_stages(
     entities = []
     await async_setup_entry(hass, mock_config_entry, lambda e: entities.extend(e))
 
-    # Only the 5 basic SENSOR_DESCRIPTIONS
-    assert len(entities) == 5
+    # Only the 5 basic SENSOR_DESCRIPTIONS + 1 DHW state sensor
+    assert len(entities) == 6
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -1,0 +1,270 @@
+"""Tests for the HBX Controls water_heater platform (DHW)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.hbx_controls.const import DOMAIN
+from custom_components.hbx_controls.water_heater import (
+    HBXDHWWaterHeater,
+    async_setup_entry,
+)
+
+from .conftest import (
+    MOCK_BUILDING_ID,
+    MOCK_DEVICE_ID,
+    make_coordinator_data,
+    make_device,
+    make_full_parameters,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_water_heater(coordinator, device_id=MOCK_DEVICE_ID, device=None, building_id=MOCK_BUILDING_ID):
+    """Create a water heater entity for testing."""
+    if device is None:
+        device = make_device(device_id=device_id)
+    return HBXDHWWaterHeater(coordinator, device_id, device, building_id)
+
+
+# ---------------------------------------------------------------------------
+# Platform setup
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_creates_water_heater(
+    hass: HomeAssistant, mock_coordinator, mock_config_entry
+):
+    """Test that a water heater entity is created when DHW is present."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, lambda e: entities.extend(e))
+
+    assert len(entities) == 1
+    assert isinstance(entities[0], HBXDHWWaterHeater)
+
+
+async def test_setup_no_dhw(
+    hass: HomeAssistant, mock_coordinator, mock_config_entry
+):
+    """Test that no water heater entity is created when DHW is absent."""
+    params = make_full_parameters(
+        dhw_enabled=None,
+        dhw_target_temp=None,
+        dhw_differential=None,
+        dhw_state=None,
+    )
+    device = make_device(parameters=params)
+    mock_coordinator.data = make_coordinator_data(devices={MOCK_DEVICE_ID: device})
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, lambda e: entities.extend(e))
+
+    assert len(entities) == 0
+
+
+async def test_setup_no_data(
+    hass: HomeAssistant, mock_coordinator_no_data, mock_config_entry
+):
+    """Test no entities when coordinator has no data."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][mock_config_entry.entry_id] = mock_coordinator_no_data
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, lambda e: entities.extend(e))
+
+    assert len(entities) == 0
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+async def test_is_on_true(mock_coordinator):
+    """Test is_on returns True when DHW is enabled."""
+    params = make_full_parameters(dhw_enabled=True)
+    device = make_device(parameters=params)
+    mock_coordinator.data = make_coordinator_data(devices={MOCK_DEVICE_ID: device})
+
+    entity = _make_water_heater(mock_coordinator)
+    assert entity.is_on is True
+
+
+async def test_is_on_false(mock_coordinator):
+    """Test is_on returns False when DHW is disabled."""
+    params = make_full_parameters(dhw_enabled=False)
+    device = make_device(parameters=params)
+    mock_coordinator.data = make_coordinator_data(devices={MOCK_DEVICE_ID: device})
+
+    entity = _make_water_heater(mock_coordinator)
+    assert entity.is_on is False
+
+
+async def test_target_temperature(mock_coordinator):
+    """Test target_temperature returns the DHW target temp value."""
+    target = MagicMock()
+    target.value = 140.0
+    params = make_full_parameters(dhw_target_temp=target)
+    device = make_device(parameters=params)
+    mock_coordinator.data = make_coordinator_data(devices={MOCK_DEVICE_ID: device})
+
+    entity = _make_water_heater(mock_coordinator)
+    assert entity.target_temperature == 140.0
+
+
+async def test_target_temperature_plain_float(mock_coordinator):
+    """Test target_temperature works with a plain float (no .value attr)."""
+    params = make_full_parameters(dhw_target_temp=135.0)
+    device = make_device(parameters=params)
+    mock_coordinator.data = make_coordinator_data(devices={MOCK_DEVICE_ID: device})
+
+    entity = _make_water_heater(mock_coordinator)
+    assert entity.target_temperature == 135.0
+
+
+async def test_current_operation_heating(mock_coordinator):
+    """Test current_operation returns 'heating' when DHW is activated."""
+    params = make_full_parameters(
+        dhw_state={"activated": True, "enabled": True, "title": "DHW"}
+    )
+    device = make_device(parameters=params)
+    mock_coordinator.data = make_coordinator_data(devices={MOCK_DEVICE_ID: device})
+
+    entity = _make_water_heater(mock_coordinator)
+    assert entity.current_operation == "heating"
+
+
+async def test_current_operation_idle(mock_coordinator):
+    """Test current_operation returns 'idle' when DHW is not activated."""
+    params = make_full_parameters(
+        dhw_state={"activated": False, "enabled": True, "title": "DHW"}
+    )
+    device = make_device(parameters=params)
+    mock_coordinator.data = make_coordinator_data(devices={MOCK_DEVICE_ID: device})
+
+    entity = _make_water_heater(mock_coordinator)
+    assert entity.current_operation == "idle"
+
+
+async def test_current_operation_no_state(mock_coordinator):
+    """Test current_operation returns None when dhw_state is absent."""
+    params = make_full_parameters(dhw_state=None)
+    device = make_device(parameters=params)
+    mock_coordinator.data = make_coordinator_data(devices={MOCK_DEVICE_ID: device})
+
+    entity = _make_water_heater(mock_coordinator)
+    assert entity.current_operation is None
+
+
+async def test_available(mock_coordinator):
+    """Test available returns True with valid data."""
+    entity = _make_water_heater(mock_coordinator)
+    assert entity.available is True
+
+
+async def test_unavailable_no_data(mock_coordinator):
+    """Test available returns False when coordinator has no data."""
+    mock_coordinator.data = None
+    entity = _make_water_heater(mock_coordinator)
+    assert entity.available is False
+
+
+async def test_unique_id(mock_coordinator):
+    """Test unique_id format."""
+    entity = _make_water_heater(mock_coordinator)
+    assert entity.unique_id == f"{MOCK_DEVICE_ID}_dhw"
+
+
+# ---------------------------------------------------------------------------
+# Actions
+# ---------------------------------------------------------------------------
+
+
+async def test_turn_on(mock_coordinator):
+    """Test turning on DHW calls the API."""
+    mock_coordinator.async_request_refresh = AsyncMock()
+
+    entity = _make_water_heater(mock_coordinator)
+
+    with patch(
+        "custom_components.hbx_controls.water_heater.SensorlinxDevice"
+    ) as mock_device_cls:
+        mock_device = MagicMock()
+        mock_device.set_dhw_enabled = AsyncMock()
+        mock_device_cls.return_value = mock_device
+
+        await entity.async_turn_on()
+
+        mock_device.set_dhw_enabled.assert_called_once_with(True)
+        mock_coordinator.async_request_refresh.assert_called_once()
+
+
+async def test_turn_off(mock_coordinator):
+    """Test turning off DHW calls the API."""
+    mock_coordinator.async_request_refresh = AsyncMock()
+
+    entity = _make_water_heater(mock_coordinator)
+
+    with patch(
+        "custom_components.hbx_controls.water_heater.SensorlinxDevice"
+    ) as mock_device_cls:
+        mock_device = MagicMock()
+        mock_device.set_dhw_enabled = AsyncMock()
+        mock_device_cls.return_value = mock_device
+
+        await entity.async_turn_off()
+
+        mock_device.set_dhw_enabled.assert_called_once_with(False)
+        mock_coordinator.async_request_refresh.assert_called_once()
+
+
+async def test_set_temperature(mock_coordinator):
+    """Test setting DHW target temperature calls the API."""
+    mock_coordinator.async_request_refresh = AsyncMock()
+
+    entity = _make_water_heater(mock_coordinator)
+
+    with patch(
+        "custom_components.hbx_controls.water_heater.SensorlinxDevice"
+    ) as mock_device_cls, patch(
+        "custom_components.hbx_controls.water_heater.Temperature"
+    ) as mock_temp_cls:
+        mock_device = MagicMock()
+        mock_device.set_dhw_target_temp = AsyncMock()
+        mock_device_cls.return_value = mock_device
+
+        mock_temp_instance = MagicMock()
+        mock_temp_cls.return_value = mock_temp_instance
+
+        await entity.async_set_temperature(temperature=145.0)
+
+        mock_temp_cls.assert_called_once_with(145.0, "F")
+        mock_device.set_dhw_target_temp.assert_called_once_with(mock_temp_instance)
+        mock_coordinator.async_request_refresh.assert_called_once()
+
+
+async def test_set_temperature_no_value(mock_coordinator):
+    """Test set_temperature does nothing when no temperature kwarg."""
+    mock_coordinator.async_request_refresh = AsyncMock()
+
+    entity = _make_water_heater(mock_coordinator)
+
+    with patch(
+        "custom_components.hbx_controls.water_heater.SensorlinxDevice"
+    ) as mock_device_cls:
+        await entity.async_set_temperature()
+        mock_device_cls.assert_not_called()
+        mock_coordinator.async_request_refresh.assert_not_called()


### PR DESCRIPTION
## Summary
Adds DHW (Domestic Hot Water) control to the HA integration using the native \water_heater\ platform, plus a DHW differential number entity and a DHW state diagnostic sensor.

## Changes
- **manifest.json / requirements.txt / tests.yml**: Bump pysensorlinx 0.1.9 → 0.2.1
- **coordinator.py**: Fetch DHW data per device (enabled, target temp, differential, state)
- **water_heater.py** (new): \HBXDHWWaterHeater\ entity with on/off, target temp (33-180°F), operation state (heating/idle)
- **number.py**: New \DHWDifferential\ number entity (2-100°F, Celsius-aware with TemperatureDelta)
- **sensor.py**: New \DHWStateSensor\ diagnostic sensor (Heating/Idle based on activated state)
- **__init__.py**: Register \Platform.WATER_HEATER\
- **conftest.py**: Add DHW parameters to \make_full_parameters()\
- **test_water_heater.py** (new): 14 tests covering setup, properties, and actions

## Notes
- Uses HA's native \water_heater\ platform — integrates with energy dashboard
- DHW differential doesn't map to any \water_heater\ attribute, so it stays as a \
umber\ entity
- All new entities follow existing patterns (device_info, availability, coordinator refresh)