### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
   "requirements": ["pysensorlinx==0.2.1"],
-  "version": "2.2.0"
+  "version": "2.3.0"
 }


### PR DESCRIPTION
Bumps version to 2.3.0 to include:
- DHW water_heater platform (PR #13)
- Weather platform with current conditions and forecast (PR #14)
- pysensorlinx dependency bumped to 0.2.1