### PR TITLE
fix: resilient login + reauth flow (pysensorlinx 0.2.3)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest pytest-asyncio==0.24.0
           pip install homeassistant==2024.3.3
-          pip install pysensorlinx==0.2.1
+          pip install pysensorlinx==0.2.3
 
       - name: Run tests
         run: python -m pytest tests/ -v --tb=short

--- a/custom_components/hbx_controls/config_flow.py
+++ b/custom_components/hbx_controls/config_flow.py
@@ -2,10 +2,17 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
+import aiohttp
 import voluptuous as vol
-from pysensorlinx import Sensorlinx
+from pysensorlinx import (
+    InvalidCredentialsError,
+    LoginError,
+    LoginTimeoutError,
+    Sensorlinx,
+)
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -40,6 +47,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for HBX Controls."""
 
     VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._reauth_entry: config_entries.ConfigEntry | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -76,6 +87,67 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> OptionsFlowHandler:
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> FlowResult:
+        """Handle reauth when the coordinator raises ConfigEntryAuthFailed."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Prompt the user for new credentials."""
+        assert self._reauth_entry is not None
+        errors: dict[str, str] = {}
+
+        existing_data = dict(self._reauth_entry.data)
+
+        if user_input is not None:
+            # Reuse the original scan_interval; the reauth dialog only
+            # collects credentials.
+            candidate = {
+                CONF_USERNAME: user_input[CONF_USERNAME],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                CONF_SCAN_INTERVAL: existing_data.get(
+                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                ),
+            }
+            try:
+                await validate_input(self.hass, candidate)
+            except CannotConnect:
+                errors["base"] = ERROR_CANNOT_CONNECT
+            except InvalidAuth:
+                errors["base"] = ERROR_AUTH_FAILED
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception during reauth")
+                errors["base"] = ERROR_UNKNOWN
+            else:
+                self.hass.config_entries.async_update_entry(
+                    self._reauth_entry, data=candidate
+                )
+                await self.hass.config_entries.async_reload(
+                    self._reauth_entry.entry_id
+                )
+                return self.async_abort(reason="reauth_successful")
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_USERNAME,
+                    default=existing_data.get(CONF_USERNAME, ""),
+                ): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=schema,
+            errors=errors,
+        )
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
@@ -185,6 +257,12 @@ async def validate_input(hass, data: dict[str, Any]) -> dict[str, Any]:
         
     except Exception as exc:
         _LOGGER.error("Failed to connect to SensorLinx: %s", exc)
-        raise CannotConnect from exc
+        if isinstance(exc, InvalidCredentialsError):
+            raise InvalidAuth from exc
+        if isinstance(exc, (LoginTimeoutError, LoginError, aiohttp.ClientError)):
+            raise CannotConnect from exc
+        # Anything else is genuinely unexpected; let async_step_user log
+        # it and surface ERROR_UNKNOWN to the user.
+        raise
     finally:
         await sensorlinx.close()

--- a/custom_components/hbx_controls/coordinator.py
+++ b/custom_components/hbx_controls/coordinator.py
@@ -5,7 +5,12 @@ import logging
 from datetime import timedelta
 from typing import Any
 
-from pysensorlinx import Sensorlinx
+from pysensorlinx import (
+    InvalidCredentialsError,
+    LoginError,
+    LoginTimeoutError,
+    Sensorlinx,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -39,12 +44,16 @@ class HBXControlsDataUpdateCoordinator(DataUpdateCoordinator):
       """Update data via library."""
       _LOGGER.debug("Starting HBX Controls data update")
       try:
-        # Login
-        _LOGGER.debug("Logging in as user: %s", self.entry.data[CONF_USERNAME])
-        await self.sensorlinx.login(
-          self.entry.data[CONF_USERNAME],
-          self.entry.data[CONF_PASSWORD]
-        )
+        # Lazy login: pysensorlinx>=0.2.3 owns session lifecycle and is
+        # idempotent when already authenticated. Skipping the call when
+        # we already hold a valid session avoids a pointless POST every
+        # poll cycle.
+        if not self.sensorlinx.is_logged_in:
+          _LOGGER.debug("Logging in as user: %s", self.entry.data[CONF_USERNAME])
+          await self.sensorlinx.login(
+            self.entry.data[CONF_USERNAME],
+            self.entry.data[CONF_PASSWORD]
+          )
         
         # Get user profile
         _LOGGER.debug("Fetching user profile")
@@ -360,6 +369,22 @@ class HBXControlsDataUpdateCoordinator(DataUpdateCoordinator):
       except ConfigEntryAuthFailed:
         _LOGGER.debug("Authentication failed during data update")
         raise
+      except InvalidCredentialsError as exc:
+        # Bad password / revoked account: surface to HA so reauth flow
+        # fires. The library has already cleaned up its session.
+        _LOGGER.warning("Invalid credentials for SensorLinx: %s", exc)
+        raise ConfigEntryAuthFailed(str(exc)) from exc
+      except (LoginTimeoutError, LoginError) as exc:
+        # Transient login failure (timeout, network, server 5xx). The
+        # library leaves itself in a not-logged-in state, so the next
+        # poll will attempt a fresh login. Defensively close to make
+        # sure no half-init session lingers.
+        _LOGGER.warning("Transient SensorLinx login failure: %s", exc)
+        try:
+          await self.sensorlinx.close()
+        except Exception:  # pylint: disable=broad-except
+          pass
+        raise UpdateFailed(f"SensorLinx login failed: {exc}") from exc
       except Exception as exc:
         _LOGGER.error("Error communicating with SensorLinx API: %s", exc)
         raise UpdateFailed(f"Error communicating with API: {exc}") from exc

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
-  "requirements": ["pysensorlinx==0.2.1"],
-  "version": "2.2.0"
+  "requirements": ["pysensorlinx==0.2.3"],
+  "version": "2.3.0"
 }

--- a/custom_components/hbx_controls/strings.json
+++ b/custom_components/hbx_controls/strings.json
@@ -12,6 +12,14 @@
         "data_description": {
           "scan_interval": "How often to fetch data from SensorLinx. Default is 300 seconds (5 minutes). Minimum 60, maximum 3600."
         }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate HBX Controls",
+        "description": "Your SensorLinx credentials are no longer valid. Please re-enter them to continue.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
       }
     },
     "error": {
@@ -20,7 +28,8 @@
       "unknown": "Unexpected error occurred"
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Reauthentication was successful"
     }
   },
   "options": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pysensorlinx==0.2.1
+pysensorlinx==0.2.3
 homeassistant>=2023.1.0

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -52,9 +52,13 @@ async def test_validate_input_success(hass):
 
 
 async def test_validate_input_login_failure(hass):
-    """Test validate_input raises CannotConnect on login failure."""
+    """Test validate_input raises CannotConnect on transport-level login failure."""
+    import aiohttp
+
     mock_sensorlinx = AsyncMock()
-    mock_sensorlinx.login = AsyncMock(side_effect=Exception("Connection error"))
+    mock_sensorlinx.login = AsyncMock(
+        side_effect=aiohttp.ClientError("Connection error")
+    )
 
     with (
         patch(
@@ -64,6 +68,73 @@ async def test_validate_input_login_failure(hass):
         pytest.raises(CannotConnect),
     ):
         await validate_input(hass, VALID_USER_INPUT)
+
+
+async def test_validate_input_invalid_credentials(hass):
+    """InvalidCredentialsError must surface as InvalidAuth, not CannotConnect."""
+    from pysensorlinx import InvalidCredentialsError
+
+    mock_sensorlinx = AsyncMock()
+    mock_sensorlinx.login = AsyncMock(
+        side_effect=InvalidCredentialsError("bad password")
+    )
+
+    with (
+        patch(
+            "custom_components.hbx_controls.config_flow.Sensorlinx",
+            return_value=mock_sensorlinx,
+        ),
+        pytest.raises(InvalidAuth),
+    ):
+        await validate_input(hass, VALID_USER_INPUT)
+
+
+async def test_validate_input_login_timeout(hass):
+    """LoginTimeoutError is treated as CannotConnect (transient)."""
+    from pysensorlinx import LoginTimeoutError
+
+    mock_sensorlinx = AsyncMock()
+    mock_sensorlinx.login = AsyncMock(side_effect=LoginTimeoutError("timed out"))
+
+    with (
+        patch(
+            "custom_components.hbx_controls.config_flow.Sensorlinx",
+            return_value=mock_sensorlinx,
+        ),
+        pytest.raises(CannotConnect),
+    ):
+        await validate_input(hass, VALID_USER_INPUT)
+
+
+async def test_validate_input_unknown_error_propagates(hass):
+    """Unknown exceptions propagate so callers can log/handle as ERROR_UNKNOWN."""
+    mock_sensorlinx = AsyncMock()
+    mock_sensorlinx.login = AsyncMock(side_effect=RuntimeError("weird"))
+
+    with (
+        patch(
+            "custom_components.hbx_controls.config_flow.Sensorlinx",
+            return_value=mock_sensorlinx,
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        await validate_input(hass, VALID_USER_INPUT)
+
+
+async def test_validate_input_closes_session_on_success(hass):
+    """validate_input must always close the temporary client."""
+    mock_sensorlinx = AsyncMock()
+    mock_sensorlinx.login = AsyncMock()
+    mock_sensorlinx.get_profile = AsyncMock(return_value={"username": "x"})
+    mock_sensorlinx.close = AsyncMock()
+
+    with patch(
+        "custom_components.hbx_controls.config_flow.Sensorlinx",
+        return_value=mock_sensorlinx,
+    ):
+        await validate_input(hass, VALID_USER_INPUT)
+
+    mock_sensorlinx.close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -232,6 +303,113 @@ async def test_options_flow_cannot_connect_new_credentials(hass):
         side_effect=CannotConnect,
     ):
         result = await flow.async_step_init(user_input=new_input)
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": ERROR_CANNOT_CONNECT}
+
+
+# ---------------------------------------------------------------------------
+# Reauth flow tests
+# ---------------------------------------------------------------------------
+
+
+async def test_reauth_form_shown(hass):
+    """async_step_reauth_confirm shows a form prepopulated with the username."""
+    entry = MagicMock()
+    entry.entry_id = "abc123"
+    entry.data = dict(VALID_USER_INPUT)
+
+    flow = ConfigFlow()
+    flow.hass = hass
+    flow.context = {"entry_id": "abc123", "source": "reauth"}
+
+    with patch.object(
+        hass.config_entries, "async_get_entry", return_value=entry
+    ):
+        result = await flow.async_step_reauth(entry.data)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+
+
+async def test_reauth_success_updates_entry_and_aborts(hass):
+    """Successful reauth updates entry credentials and aborts with reauth_successful."""
+    entry = MagicMock()
+    entry.entry_id = "abc123"
+    entry.data = dict(VALID_USER_INPUT)
+
+    flow = ConfigFlow()
+    flow.hass = hass
+    flow.context = {"entry_id": "abc123", "source": "reauth"}
+    flow._reauth_entry = entry
+
+    new_creds = {
+        CONF_USERNAME: "new@example.com",
+        CONF_PASSWORD: "new_password",
+    }
+
+    with (
+        patch(
+            "custom_components.hbx_controls.config_flow.validate_input",
+            return_value={"title": "HBX Controls (new@example.com)"},
+        ),
+        patch.object(
+            hass.config_entries, "async_update_entry"
+        ) as mock_update,
+        patch.object(
+            hass.config_entries, "async_reload", new_callable=AsyncMock
+        ) as mock_reload,
+    ):
+        result = await flow.async_step_reauth_confirm(user_input=new_creds)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+    mock_update.assert_called_once()
+    mock_reload.assert_called_once_with("abc123")
+
+
+async def test_reauth_invalid_auth_shows_form_with_error(hass):
+    """Bad credentials during reauth re-show the form with ERROR_AUTH_FAILED."""
+    entry = MagicMock()
+    entry.entry_id = "abc123"
+    entry.data = dict(VALID_USER_INPUT)
+
+    flow = ConfigFlow()
+    flow.hass = hass
+    flow.context = {"entry_id": "abc123", "source": "reauth"}
+    flow._reauth_entry = entry
+
+    with patch(
+        "custom_components.hbx_controls.config_flow.validate_input",
+        side_effect=InvalidAuth,
+    ):
+        result = await flow.async_step_reauth_confirm(
+            user_input={CONF_USERNAME: "x", CONF_PASSWORD: "y"}
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": ERROR_AUTH_FAILED}
+
+
+async def test_reauth_cannot_connect_shows_form_with_error(hass):
+    """Transient failure during reauth re-shows the form with ERROR_CANNOT_CONNECT."""
+    entry = MagicMock()
+    entry.entry_id = "abc123"
+    entry.data = dict(VALID_USER_INPUT)
+
+    flow = ConfigFlow()
+    flow.hass = hass
+    flow.context = {"entry_id": "abc123", "source": "reauth"}
+    flow._reauth_entry = entry
+
+    with patch(
+        "custom_components.hbx_controls.config_flow.validate_input",
+        side_effect=CannotConnect,
+    ):
+        result = await flow.async_step_reauth_confirm(
+            user_input={CONF_USERNAME: "x", CONF_PASSWORD: "y"}
+        )
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": ERROR_CANNOT_CONNECT}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -29,9 +29,14 @@ def _make_mock_sensorlinx(
     profile: dict | None = None,
     buildings: list[dict] | None = None,
     devices: list[dict] | None = None,
+    is_logged_in: bool = False,
 ):
     """Return a mocked Sensorlinx object for coordinator tests."""
     mock = AsyncMock()
+    # is_logged_in is a plain bool property on the real class; the
+    # coordinator's lazy-login path checks it before calling login().
+    # AsyncMock would otherwise return a truthy mock and skip login.
+    mock.is_logged_in = is_logged_in
     mock.login = AsyncMock()
     mock.get_profile = AsyncMock(
         return_value=profile if profile is not None else {"username": MOCK_USERNAME}
@@ -242,3 +247,119 @@ async def test_update_data_device_falls_back_to_id(hass: HomeAssistant, mock_con
         result = await coordinator._async_update_data()
 
     assert "device_99" in result["devices"]
+
+
+# ---------------------------------------------------------------------------
+# Login resilience tests (PR #login-resilience)
+# ---------------------------------------------------------------------------
+
+
+async def test_update_data_skips_login_when_already_logged_in(
+    hass: HomeAssistant, mock_config_entry
+):
+    """Lazy login: subsequent polls should not re-authenticate."""
+    coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
+    mock_sl = _make_mock_sensorlinx(is_logged_in=True)
+    coordinator.sensorlinx = mock_sl
+
+    await coordinator._async_update_data()
+
+    mock_sl.login.assert_not_called()
+    mock_sl.get_profile.assert_called_once()
+
+
+async def test_update_data_logs_in_when_not_authenticated(
+    hass: HomeAssistant, mock_config_entry
+):
+    """First poll (or post-failure) must call login()."""
+    coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
+    mock_sl = _make_mock_sensorlinx(is_logged_in=False)
+    coordinator.sensorlinx = mock_sl
+
+    await coordinator._async_update_data()
+
+    mock_sl.login.assert_called_once_with(MOCK_USERNAME, MOCK_PASSWORD)
+
+
+async def test_update_data_invalid_credentials_triggers_reauth(
+    hass: HomeAssistant, mock_config_entry
+):
+    """InvalidCredentialsError from login() must surface as ConfigEntryAuthFailed."""
+    from pysensorlinx import InvalidCredentialsError
+
+    coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
+    mock_sl = _make_mock_sensorlinx()
+    mock_sl.login = AsyncMock(side_effect=InvalidCredentialsError("bad password"))
+    coordinator.sensorlinx = mock_sl
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+async def test_update_data_invalid_credentials_from_data_call(
+    hass: HomeAssistant, mock_config_entry
+):
+    """A 401-driven InvalidCredentialsError mid-poll must also surface as auth-failed."""
+    from pysensorlinx import InvalidCredentialsError
+
+    coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
+    mock_sl = _make_mock_sensorlinx(is_logged_in=True)
+    mock_sl.get_profile = AsyncMock(side_effect=InvalidCredentialsError("token revoked"))
+    coordinator.sensorlinx = mock_sl
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+async def test_update_data_login_timeout_is_transient(
+    hass: HomeAssistant, mock_config_entry
+):
+    """LoginTimeoutError must become UpdateFailed (not ConfigEntryAuthFailed)."""
+    from pysensorlinx import LoginTimeoutError
+
+    coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
+    mock_sl = _make_mock_sensorlinx()
+    mock_sl.login = AsyncMock(side_effect=LoginTimeoutError("timed out"))
+    coordinator.sensorlinx = mock_sl
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    # Defensive close so the next cycle starts clean.
+    mock_sl.close.assert_called_once()
+
+
+async def test_update_data_login_error_is_transient(
+    hass: HomeAssistant, mock_config_entry
+):
+    """LoginError (server 5xx etc.) must become UpdateFailed."""
+    from pysensorlinx import LoginError
+
+    coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
+    mock_sl = _make_mock_sensorlinx()
+    mock_sl.login = AsyncMock(side_effect=LoginError("502 bad gateway"))
+    coordinator.sensorlinx = mock_sl
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    mock_sl.close.assert_called_once()
+
+
+async def test_update_data_recovers_on_next_cycle(
+    hass: HomeAssistant, mock_config_entry
+):
+    """After a transient login failure, the next cycle should succeed."""
+    from pysensorlinx import LoginTimeoutError
+
+    coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
+    mock_sl = _make_mock_sensorlinx()
+    mock_sl.login = AsyncMock(side_effect=[LoginTimeoutError("t/o"), None])
+    coordinator.sensorlinx = mock_sl
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    # Second cycle: simulate library having cleaned up; not yet logged in.
+    mock_sl.is_logged_in = False
+    result = await coordinator._async_update_data()
+    assert "profile" in result
+    assert mock_sl.login.call_count == 2


### PR DESCRIPTION
## What & Why

Real-world bug: when the SensorLinx login request times out, the
integration logs `Login request timed out.` and then never recovers —
the user has to manually reload it. Token expiry mid-day causes the
same dead-end.

Root cause was a half-initialised state in pysensorlinx (session
created but no bearer) that has now been fixed in
[pysensorlinx#20](https://github.com/sslivins/pysensorlinx/pull/20)
(shipped as `0.2.3`). This PR pins the new release, takes advantage
of its lazy/idempotent login, maps its typed exceptions correctly,
and adds the missing reauth flow so users with revoked credentials
get a credential dialog instead of a disabled entry.

## Changes

### Dependencies
- `manifest.json` & `requirements.txt`: pin `pysensorlinx==0.2.3`.
- `manifest.json`: bump integration version `2.2.0` → `2.3.0`
  (reauth + error semantics are user-visible).
- `.github/workflows/tests.yml`: install `pysensorlinx==0.2.3` for CI.

### Coordinator (`coordinator.py`)
- Lazy login: skip `login()` when `sensorlinx.is_logged_in` is True.
  No more pointless POST every 5 minutes.
- Map `InvalidCredentialsError` → `ConfigEntryAuthFailed` (triggers
  reauth).
- Map `LoginTimeoutError` / `LoginError` → `UpdateFailed` and
  defensively call `close()` so the next cycle starts clean.

### Config flow (`config_flow.py`)
- Tighten `validate_input` exception mapping:
  - `InvalidCredentialsError` → `InvalidAuth`
  - `LoginTimeoutError` / `LoginError` / `aiohttp.ClientError` → `CannotConnect`
  - Anything else propagates so `async_step_user` logs it and surfaces
    `ERROR_UNKNOWN`. Previously every exception was wrapped as
    `CannotConnect`, masking bad-password failures at initial setup.
- Add `async_step_reauth` + `async_step_reauth_confirm` so
  `ConfigEntryAuthFailed` produces a credential dialog rather than
  silently disabling the entry. `reauth_confirm` reuses existing
  schema (username + password) and preserves the entry's
  `scan_interval`.
- New strings: `config.step.reauth_confirm` and
  `config.abort.reauth_successful`.

## Tests

8 new coordinator tests + 8 new config-flow tests covering:
- Lazy-login (skips when already authenticated, runs when not).
- `InvalidCredentialsError` → `ConfigEntryAuthFailed` at both login
  and during data calls.
- `LoginTimeoutError` / `LoginError` → `UpdateFailed` + `close()`.
- Recovery on the cycle after a transient failure.
- `validate_input` typed-exception mapping (incl. the unknown-error
  propagation path).
- `validate_input` always closes its temporary client.
- Full reauth flow: form shown, success updates entry & aborts with
  `reauth_successful`, errors re-show form with the correct error.

`_make_mock_sensorlinx` now sets `is_logged_in` as a real bool.
Without this, `AsyncMock`'s auto-attribute returns a truthy mock and
the lazy-login path silently skips `login()` in tests, hiding
regressions. The duck flagged this in the planning round and it's
now covered explicitly.

## Risk

Low. All API surface is internal; `pysensorlinx==0.2.3` is already
on PyPI; the new exception mapping is strictly more correct than the
old catch-all. The reauth flow is additive — no existing code path
loses functionality.

## Closes
- Fixes the user-reported `Login request timed out.` recovery bug.
