### PR TITLE
fix(weather): clearer device name + mark as service device

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'custom_components/hbx_controls/manifest.json'
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from manifest.json
+        id: version
+        run: |
+          VERSION=$(python3 -c "import json; print(json.load(open('custom_components/hbx_controls/manifest.json'))['version'])")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Detected version: ${VERSION}"
+
+      - name: Skip if tag already exists
+        id: check_tag
+        run: |
+          if git rev-parse "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.version.outputs.tag }} already exists; nothing to release."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Generate changelog
+        if: steps.check_tag.outputs.exists == 'false'
+        id: changelog
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${TAG}$" | head -n1)
+          if [ -z "$PREV_TAG" ]; then
+            RANGE="HEAD"
+          else
+            RANGE="${PREV_TAG}..HEAD"
+          fi
+          echo "Generating changelog: ${PREV_TAG:-initial}..${TAG}"
+
+          FEATURES=$(git log ${RANGE} --oneline --no-merges --grep="^feat" | sed 's/^[a-f0-9]* feat[^:]*: //' || true)
+          FIXES=$(git log ${RANGE} --oneline --no-merges --grep="^fix" | sed 's/^[a-f0-9]* fix[^:]*: //' || true)
+          TESTS=$(git log ${RANGE} --oneline --no-merges --grep="^test" | sed 's/^[a-f0-9]* test[^:]*: //' || true)
+          DOCS=$(git log ${RANGE} --oneline --no-merges --grep="^docs" | sed 's/^[a-f0-9]* docs[^:]*: //' || true)
+          CHORE=$(git log ${RANGE} --oneline --no-merges --grep="^chore" | sed 's/^[a-f0-9]* chore[^:]*: //' || true)
+          CI_CHANGES=$(git log ${RANGE} --oneline --no-merges --grep="^ci" | sed 's/^[a-f0-9]* ci[^:]*: //' || true)
+
+          {
+            echo "## HBX Controls ${TAG}"
+            echo ""
+            if [ -n "$FEATURES" ]; then
+              echo "### ✨ Features"
+              echo "$FEATURES" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$FIXES" ]; then
+              echo "### 🐛 Fixes"
+              echo "$FIXES" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$TESTS" ]; then
+              echo "### 🧪 Tests"
+              echo "$TESTS" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$DOCS" ]; then
+              echo "### 📝 Documentation"
+              echo "$DOCS" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$CHORE" ]; then
+              echo "### 🧹 Chores"
+              echo "$CHORE" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$CI_CHANGES" ]; then
+              echo "### 🔧 CI"
+              echo "$CI_CHANGES" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$PREV_TAG" ]; then
+              echo "**Full diff:** https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
+            fi
+          } > /tmp/release_body.md
+
+          cat /tmp/release_body.md
+
+      - name: Create GitHub Release
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          body_path: /tmp/release_body.md

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
   "requirements": ["pysensorlinx==0.2.3"],
-  "version": "2.3.0"
+  "version": "2.3.1"
 }

--- a/custom_components/hbx_controls/weather.py
+++ b/custom_components/hbx_controls/weather.py
@@ -16,6 +16,8 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -99,11 +101,14 @@ class HBXWeather(CoordinatorEntity, WeatherEntity):
         self._building_id = building_id
         self._attr_unique_id = f"{building_id}_weather"
         self._attr_name = "Weather"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, building_id)},
-            "name": building.get("name", building_id),
-            "manufacturer": "HBX Controls",
-        }
+        building_name = building.get("name") or "HBX Building"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, building_id)},
+            name=f"{building_name} Weather",
+            manufacturer="HBX Controls",
+            model="Building Weather",
+            entry_type=DeviceEntryType.SERVICE,
+        )
 
     @property
     def _weather_data(self) -> dict[str, Any]:

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -198,11 +198,29 @@ class TestWeatherProperties:
     @pytest.mark.asyncio
     async def test_device_info(self, hass, mock_coordinator, mock_config_entry):
         """Test device info references the building."""
+        from homeassistant.helpers.device_registry import DeviceEntryType
+
         entity = await self._setup_entity(hass, mock_coordinator, mock_config_entry)
         info = entity.device_info
         assert (DOMAIN, MOCK_BUILDING_ID) in info["identifiers"]
-        assert info["name"] == "Test Building"
+        assert info["name"] == "Test Building Weather"
         assert info["manufacturer"] == "HBX Controls"
+        assert info["model"] == "Building Weather"
+        assert info["entry_type"] == DeviceEntryType.SERVICE
+
+    @pytest.mark.asyncio
+    async def test_device_info_no_building_name(
+        self, hass, mock_coordinator, mock_config_entry
+    ):
+        """Device name never falls back to the raw building_id."""
+        # Strip the building name so the fallback path is exercised
+        for b in mock_coordinator.data["buildings"]:
+            b.pop("name", None)
+
+        entity = await self._setup_entity(hass, mock_coordinator, mock_config_entry)
+        info = entity.device_info
+        assert info["name"] == "HBX Building Weather"
+        assert MOCK_BUILDING_ID not in info["name"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The weather entity (added in #14) creates its own device in HA keyed on the building, separate from the heat-pump device. That's correct in principle (one HBX building can host multiple devices but only one weather location), **but** the device name fell back to the raw `building_id` (a Mongo ObjectId-style hex string) when the building had no `name` set in HBX. Result: a device appeared in HA called something like `682f8a1b3c…` with no obvious purpose.

## Fix

`custom_components/hbx_controls/weather.py`:

- **Name fallback** — never expose the raw `building_id` to the user. Use `"{building name} Weather"`, falling back to `"HBX Building Weather"` when the building has no name.
- **`model: "Building Weather"`** — makes it clear at a glance what the device represents.
- **`entry_type: DeviceEntryType.SERVICE`** — marks it as a virtual/service device rather than physical hardware (it's a cloud-derived entity, not a piece of HBX hardware).
- Switched to the typed `DeviceInfo` helper.

The device `identifiers` are unchanged (`(DOMAIN, building_id)`), so existing installs keep their device registry entry — only the displayed name/model change.

## Tests

- Updated `test_device_info` to assert the new name/model/entry_type.
- Added `test_device_info_no_building_name` to verify the fallback never leaks the building_id into the display name.

## Why a separate "device" at all?

Weather is per-building in HBX (geocoded to the building location), not per heat pump. If you have multiple HBX devices in one building, you want one weather entity, not N. So keeping it as its own device is the right model — just needed cleaner presentation.

## Version

Bumped to `2.3.1`. Auto-release workflow will tag and publish on merge.
