### PR TITLE
fix: transient profile fetch failure should not force reauth

### DIFF
--- a/custom_components/hbx_controls/coordinator.py
+++ b/custom_components/hbx_controls/coordinator.py
@@ -290,8 +290,16 @@ class HBXControlsDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("Fetching user profile")
             profile = await self.sensorlinx.get_profile()
             if not profile:
+                # pysensorlinx.get_profile() returns None on transient API
+                # failures (network blip, 5xx, timeout, JSON decode error) and
+                # only raises LoginError for actual auth issues. So a None
+                # return here means "API hiccup", not "bad credentials" —
+                # raise UpdateFailed so HA retries next cycle instead of
+                # kicking the user into the reauth flow. Real auth failures
+                # are caught by the InvalidCredentialsError / LoginError
+                # branches below.
                 _LOGGER.debug("No profile returned from HBX Controls")
-                raise ConfigEntryAuthFailed("Failed to get user profile")
+                raise UpdateFailed("Failed to get user profile")
 
             _LOGGER.debug("Fetching buildings")
             buildings = await self.sensorlinx.get_buildings()

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
   "requirements": ["pysensorlinx==0.3.0"],
-  "version": "2.4.0b1"
+  "version": "2.4.0b2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.4.0b1"
+version = "2.4.0b2"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -145,14 +145,20 @@ async def test_update_data_success(hass: HomeAssistant, mock_config_entry):
     mock_sl.get_buildings.assert_called_once()
 
 
-async def test_update_data_auth_failed(hass: HomeAssistant, mock_config_entry):
-    """Test ConfigEntryAuthFailed is raised when profile is None."""
+async def test_update_data_profile_none_is_transient(hass: HomeAssistant, mock_config_entry):
+    """A None profile means transient API failure → UpdateFailed, NOT reauth.
+
+    pysensorlinx.get_profile() swallows non-auth exceptions and returns None.
+    Mapping that to ConfigEntryAuthFailed forced users into the reauth flow on
+    every transient HBX API hiccup. Real auth failures raise LoginError /
+    InvalidCredentialsError and are tested separately below.
+    """
     coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
     mock_sl = _make_mock_sensorlinx(profile=None)
     mock_sl.get_profile = AsyncMock(return_value=None)
     coordinator.sensorlinx = mock_sl
 
-    with pytest.raises(ConfigEntryAuthFailed):
+    with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
 
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced in `2.3.0` (`fix: resilient login + reauth flow`, PR #17) where transient HBX API failures kick users into HA's reauth flow and force them to re-enter their password.

You hit this twice in a few hours and so did at least one other user — sorry about that.

## Root cause

`pysensorlinx.get_profile()` is intentionally forgiving: it catches non-auth exceptions (network blip, 5xx, timeout, JSON decode error) and returns `None`. Only actual `LoginError`s are re-raised. The coordinator was mapping `profile is None` straight to `ConfigEntryAuthFailed`, which HA interprets as "credentials are bad" → triggers the reauth flow → user has to re-enter password.

Real auth failures still raise `InvalidCredentialsError` / `LoginError` and are caught by dedicated branches lower in the handler. So a `None` profile after a successful login is **unambiguously transient**, not an auth issue.

## Fix

Map `profile is None` to `UpdateFailed` instead. HA will:
- mark the integration as "unavailable" for that poll cycle,
- retry on the next scheduled update (default 60s), and
- **leave the config entry alone**.

If the underlying issue persists, you'll see "unavailable" entities until the API recovers, but you won't have to re-enter your password.

## Tests

- Renamed `test_update_data_auth_failed` → `test_update_data_profile_none_is_transient` and flipped the expectation to `UpdateFailed`.
- Reauth path still covered by:
  - `test_update_data_invalid_credentials_triggers_reauth` (bad password at login)
  - `test_update_data_invalid_credentials_from_data_call` (token revoked mid-session → `InvalidCredentialsError` from `get_profile`)
- `test_update_data_login_timeout_is_transient` and `test_update_data_login_error_is_transient` continue to assert that `LoginError`/`LoginTimeoutError` map to `UpdateFailed`.

## Version

`2.4.0b1` → `2.4.0b2` (still beta — THM/ZON read-only support is unchanged).
