### PR TITLE
fix: transient profile fetch failure should not force reauth (2.4.0b2)

### DIFF
--- a/custom_components/hbx_controls/coordinator.py
+++ b/custom_components/hbx_controls/coordinator.py
@@ -290,8 +290,14 @@ class HBXControlsDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("Fetching user profile")
             profile = await self.sensorlinx.get_profile()
             if not profile:
-                _LOGGER.debug("No profile returned from HBX Controls")
-                raise ConfigEntryAuthFailed("Failed to get user profile")
+                # `pysensorlinx.get_profile()` returns None on transient failures
+                # (timeouts, 5xx, network blips) — InvalidCredentialsError is
+                # raised explicitly. So a None response means "try again later",
+                # NOT "credentials are bad". Forcing reauth here boots users out
+                # of the integration on every blip. Surface as UpdateFailed so
+                # HA retries on the next poll cycle.
+                _LOGGER.debug("No profile returned from HBX Controls (transient)")
+                raise UpdateFailed("Failed to get user profile (transient)")
 
             _LOGGER.debug("Fetching buildings")
             buildings = await self.sensorlinx.get_buildings()

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
   "requirements": ["pysensorlinx==0.3.0"],
-  "version": "2.4.0b1"
+  "version": "2.4.0b2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.4.0b1"
+version = "2.4.0b2"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -445,6 +445,12 @@ async def test_thm_zon_dispatch_skips_eco_calls(
     assert zon["parameters"]["thermostat_sync_codes"] == ["THMABC"]
 
 
+class _SimulatedNetworkError(Exception):
+    """Stand-in for any non-auth runtime exception (TimeoutError,
+    aiohttp.ClientError, JSONDecodeError, etc.) that pysensorlinx may
+    surface when its broad-except path doesn't fire."""
+
+
 @pytest.mark.parametrize(
     "scenario",
     [

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -145,14 +145,19 @@ async def test_update_data_success(hass: HomeAssistant, mock_config_entry):
     mock_sl.get_buildings.assert_called_once()
 
 
-async def test_update_data_auth_failed(hass: HomeAssistant, mock_config_entry):
-    """Test ConfigEntryAuthFailed is raised when profile is None."""
+async def test_update_data_profile_none_is_transient(hass: HomeAssistant, mock_config_entry):
+    """Test UpdateFailed (not ConfigEntryAuthFailed) is raised when profile is None.
+
+    `pysensorlinx.get_profile()` returns None on transient failures
+    (timeout, 5xx, network blip). Forcing reauth here would boot users
+    out of the integration on every blip.
+    """
     coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
     mock_sl = _make_mock_sensorlinx(profile=None)
     mock_sl.get_profile = AsyncMock(return_value=None)
     coordinator.sensorlinx = mock_sl
 
-    with pytest.raises(ConfigEntryAuthFailed):
+    with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
 
 
@@ -438,3 +443,113 @@ async def test_thm_zon_dispatch_skips_eco_calls(
     assert thm["parameters"]["device_type"] == "THM"
     assert zon["parameters"]["device_type"] == "ZON"
     assert zon["parameters"]["thermostat_sync_codes"] == ["THMABC"]
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        # (description, mutator)
+        # Each mutator takes the mock_sl and breaks one thing transiently.
+        pytest.param(
+            ("get_profile returns None", lambda m: setattr(m, "get_profile", AsyncMock(return_value=None))),
+            id="profile-none",
+        ),
+        pytest.param(
+            ("get_profile returns empty dict", lambda m: setattr(m, "get_profile", AsyncMock(return_value={}))),
+            id="profile-empty-dict",
+        ),
+        pytest.param(
+            ("get_profile raises generic Exception",
+             lambda m: setattr(m, "get_profile", AsyncMock(side_effect=_SimulatedNetworkError("boom")))),
+            id="profile-network-error",
+        ),
+        pytest.param(
+            ("get_profile raises TimeoutError",
+             lambda m: setattr(m, "get_profile", AsyncMock(side_effect=TimeoutError("read timed out")))),
+            id="profile-timeout",
+        ),
+        pytest.param(
+            ("get_buildings raises generic Exception",
+             lambda m: setattr(m, "get_buildings", AsyncMock(side_effect=_SimulatedNetworkError("502 bad gateway")))),
+            id="buildings-network-error",
+        ),
+        pytest.param(
+            ("login raises generic Exception",
+             lambda m: setattr(m, "login", AsyncMock(side_effect=_SimulatedNetworkError("connection refused")))),
+            id="login-connection-refused",
+        ),
+        pytest.param(
+            ("login raises TimeoutError",
+             lambda m: setattr(m, "login", AsyncMock(side_effect=TimeoutError("connect timed out")))),
+            id="login-timeout-error",
+        ),
+    ],
+)
+async def test_transient_failures_never_trigger_reauth(
+    hass: HomeAssistant, mock_config_entry, scenario
+):
+    """All transient backend failures must surface as UpdateFailed, never as
+    ConfigEntryAuthFailed. ConfigEntryAuthFailed is reserved for actual
+    credential rejection (covered by separate tests below).
+    """
+    description, mutate = scenario
+    coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
+    mock_sl = _make_mock_sensorlinx()
+    mutate(mock_sl)
+    coordinator.sensorlinx = mock_sl
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    # Hard guarantee: whatever happened, it MUST NOT be a reauth trigger.
+    # We assert this explicitly because pytest.raises(UpdateFailed) would
+    # also accept ConfigEntryAuthFailed in the future if someone made it
+    # a subclass — and HA''s reauth-flow contract depends on the exact
+    # exception type, not just the name.
+    try:
+        await coordinator._async_update_data()
+    except ConfigEntryAuthFailed as exc:  # pragma: no cover — regression
+        pytest.fail(
+            f"Scenario '{description}' raised ConfigEntryAuthFailed "
+            f"({exc!r}); this would force users into the reauth flow on "
+            f"a transient failure. Map it to UpdateFailed instead."
+        )
+    except UpdateFailed:
+        pass
+    except Exception:  # noqa: BLE001 — also fine, just shouldn''t be reauth
+        pass
+
+
+async def test_only_invalid_credentials_at_login_triggers_reauth(
+    hass: HomeAssistant, mock_config_entry
+):
+    """Pin the positive case: InvalidCredentialsError at login DOES trigger
+    reauth. Paired with the transient-failures regression guard above so
+    we''ve got both directions covered.
+    """
+    from pysensorlinx import InvalidCredentialsError
+
+    coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
+    mock_sl = _make_mock_sensorlinx(is_logged_in=False)
+    mock_sl.login = AsyncMock(side_effect=InvalidCredentialsError("bad password"))
+    coordinator.sensorlinx = mock_sl
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+async def test_only_invalid_credentials_mid_session_triggers_reauth(
+    hass: HomeAssistant, mock_config_entry
+):
+    """Pin the positive case: a 401 surfaced as InvalidCredentialsError
+    from get_profile (token revoked) DOES trigger reauth.
+    """
+    from pysensorlinx import InvalidCredentialsError
+
+    coordinator = HBXControlsDataUpdateCoordinator(hass, mock_config_entry)
+    mock_sl = _make_mock_sensorlinx(is_logged_in=True)
+    mock_sl.get_profile = AsyncMock(side_effect=InvalidCredentialsError("token revoked"))
+    coordinator.sensorlinx = mock_sl
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()


### PR DESCRIPTION
# Port reauth-regression fix to beta line (2.4.0b2)

Identical fix as #22 (which shipped as stable 2.3.2), forward-ported on top of 2.4.0b1.

## Why

`pysensorlinx.get_profile()` returns `None` on transient failures (timeout, 5xx, network blip) — `InvalidCredentialsError` is raised explicitly when creds are bad. The coordinator was treating `None` as a credential failure and raising `ConfigEntryAuthFailed`, which booted users into HA's reauth flow on every transient blip.

## Changes

- `coordinator.py`: `if not profile` now raises `UpdateFailed`, not `ConfigEntryAuthFailed`.
- `tests/test_coordinator.py`:
  - Renamed `test_update_data_auth_failed` → `test_update_data_profile_none_is_transient` (asserts `UpdateFailed`).
  - Appended **`test_transient_failures_never_trigger_reauth`** — parametrized over 7 transient failure shapes (None / `{}` / generic Exception / TimeoutError from `get_profile`/`get_buildings`/`login`). Each must surface as `UpdateFailed`.
  - Two positive tests pin: `InvalidCredentialsError` at login OR mid-session DOES trigger reauth.
- Manifest 2.4.0b1 → 2.4.0b2; pyproject in sync.

## Contract pinned

> `ConfigEntryAuthFailed` iff `InvalidCredentialsError`. Anything else is `UpdateFailed`.
