### PR TITLE
feat: 2.5.0b1 — THM climate entity + ZON app button & aux setpoint

### DIFF
--- a/custom_components/hbx_controls/climate.py
+++ b/custom_components/hbx_controls/climate.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pysensorlinx import DEVICE_TYPE_THM
+from pysensorlinx.sensorlinx import Temperature, ThmDevice
+
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
@@ -22,6 +25,26 @@ from .coordinator import HBXControlsDataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
+# Map between HA HVACMode values and the strings :py:meth:`ThmDevice.set_hvac_mode`
+# accepts. ``ThmDevice.set_hvac_mode`` writes the matching ``cngOvr`` integer.
+_THM_HVAC_TO_LIB = {
+    HVACMode.OFF: "off",
+    HVACMode.HEAT: "heat",
+    HVACMode.COOL: "cool",
+    HVACMode.AUTO: "auto",
+}
+
+# Friendly names HA shows for fan modes; mapped to library values when writing.
+_THM_FAN_OFF = "off"
+_THM_FAN_ON = "on"
+_THM_FAN_INTERMITTENT = "intermittent"
+_THM_FAN_MODES = [_THM_FAN_OFF, _THM_FAN_ON, _THM_FAN_INTERMITTENT]
+
+_THM_PRESET_NONE = "none"
+_THM_PRESET_AWAY = "away"
+_THM_PRESET_MODES = [_THM_PRESET_NONE, _THM_PRESET_AWAY]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -35,7 +58,22 @@ async def async_setup_entry(
     if coordinator.data and "devices" in coordinator.data:
         for device_id, device in coordinator.data["devices"].items():
             parameters = device.get("parameters", {})
-            # Create climate entity for any device that has temperature data
+            dtype = (parameters.get("device_type") or device.get("deviceType") or "").upper()
+
+            if dtype == DEVICE_TYPE_THM:
+                # THM thermostats have room/floor temps and the climate write
+                # surfaces backed by ``ThmDevice`` setters added in
+                # pysensorlinx 0.4.0.
+                entities.append(
+                    HBXControlsThmClimate(
+                        coordinator,
+                        device_id,
+                        device,
+                    )
+                )
+                continue
+
+            # Existing ECO heat-pump climate entity (preserved verbatim).
             if "target_temperature_tank" in parameters or "temperature_tank" in parameters:
                 entities.append(
                     HBXControlsClimate(
@@ -256,3 +294,250 @@ class HBXControlsClimate(CoordinatorEntity, ClimateEntity):
             and "devices" in self.coordinator.data
             and self._device_id in self.coordinator.data["devices"]
         )
+
+
+class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
+    """
+    Climate entity for THM-style thermostats (e.g. THM-0600).
+
+    Backed by :class:`pysensorlinx.sensorlinx.ThmDevice` setters introduced
+    in pysensorlinx 0.4.0:
+
+    * HVAC mode    -> ``cngOvr`` (auto/heat/cool/off)
+    * Fan mode     -> ``fnMode`` (off/on/intermittent)
+    * Setpoint     -> ``target.value`` (°F int)
+    * Away preset  -> ``away`` (0/1)
+
+    Reads come from the parameter dict the coordinator extracts via
+    :func:`coordinator._extract_thm_parameters`.
+    """
+
+    _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
+    _attr_min_temp = 35
+    _attr_max_temp = 99
+    _attr_target_temperature_step = 1
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.AUTO]
+    _attr_fan_modes = _THM_FAN_MODES
+    _attr_preset_modes = _THM_PRESET_MODES
+
+    def __init__(
+        self,
+        coordinator: HBXControlsDataUpdateCoordinator,
+        device_id: str,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize the THM climate entity."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._device = device
+        self._building_id = device.get("building_id")
+
+        self._attr_unique_id = f"{device_id}_thm_climate"
+        self._attr_name = f"{device.get('name', device_id)} Climate"
+
+        self._attr_supported_features = (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.PRESET_MODE
+            | ClimateEntityFeature.TURN_ON
+            | ClimateEntityFeature.TURN_OFF
+        )
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "name": device.get("name", device_id),
+            "manufacturer": "HBX Controls",
+            "model": device.get("deviceType", "Unknown"),
+            "sw_version": device.get("firmware_version"),
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _params(self) -> dict[str, Any] | None:
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return None
+        return device.get("parameters") or {}
+
+    def _device_helper(self) -> ThmDevice:
+        return ThmDevice(
+            self.coordinator.sensorlinx,
+            self._building_id,
+            self._device_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Read-side properties
+    # ------------------------------------------------------------------
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current room temperature."""
+        params = self._params()
+        if not params:
+            return None
+        return params.get("temperature_room")
+
+    @property
+    def current_humidity(self) -> int | None:
+        """Return the current relative humidity."""
+        params = self._params()
+        if not params:
+            return None
+        humidity = params.get("humidity")
+        try:
+            return int(round(humidity)) if humidity is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the active target temperature."""
+        params = self._params()
+        if not params:
+            return None
+        return params.get("target_temperature_room")
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        """Return current HVAC mode."""
+        params = self._params()
+        if not params:
+            return None
+        mode = (params.get("hvac_mode") or "").lower()
+        if mode == "off":
+            return HVACMode.OFF
+        if mode == "heat":
+            return HVACMode.HEAT
+        if mode == "cool":
+            return HVACMode.COOL
+        if mode == "auto":
+            return HVACMode.AUTO
+        return None
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return current HVAC action (heating/cooling/idle/off)."""
+        params = self._params()
+        if not params:
+            return None
+        if params.get("is_off"):
+            return HVACAction.OFF
+        if params.get("is_heating"):
+            return HVACAction.HEATING
+        if params.get("is_cooling"):
+            return HVACAction.COOLING
+        return HVACAction.IDLE
+
+    @property
+    def fan_mode(self) -> str | None:
+        """Return current fan mode."""
+        params = self._params()
+        if not params:
+            return None
+        mode = (params.get("fan_mode") or "").lower()
+        if mode in _THM_FAN_MODES:
+            return mode
+        return None
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return current preset mode (away/none)."""
+        params = self._params()
+        if not params:
+            return None
+        if params.get("away_mode_activated"):
+            return _THM_PRESET_AWAY
+        return _THM_PRESET_NONE
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and "devices" in self.coordinator.data
+            and self._device_id in self.coordinator.data["devices"]
+        )
+
+    # ------------------------------------------------------------------
+    # Write-side methods
+    # ------------------------------------------------------------------
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Send the new changeover state to the device."""
+        lib_mode = _THM_HVAC_TO_LIB.get(hvac_mode)
+        if lib_mode is None:
+            _LOGGER.error(
+                "Unsupported THM HVAC mode requested: %s", hvac_mode
+            )
+            return
+        try:
+            await self._device_helper().set_hvac_mode(lib_mode)
+            await self.coordinator.async_request_refresh()
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to set THM HVAC mode for %s: %s", self._device_id, exc
+            )
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Send the new fan mode to the device."""
+        if fan_mode not in _THM_FAN_MODES:
+            _LOGGER.error("Unsupported THM fan mode requested: %s", fan_mode)
+            return
+        try:
+            await self._device_helper().set_fan_mode(fan_mode)
+            await self.coordinator.async_request_refresh()
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to set THM fan mode for %s: %s", self._device_id, exc
+            )
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Toggle the THM Away preset based on requested preset."""
+        if preset_mode not in _THM_PRESET_MODES:
+            _LOGGER.error(
+                "Unsupported THM preset mode requested: %s", preset_mode
+            )
+            return
+        try:
+            await self._device_helper().set_away_mode(
+                preset_mode == _THM_PRESET_AWAY
+            )
+            await self.coordinator.async_request_refresh()
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to set THM preset mode for %s: %s",
+                self._device_id, exc,
+            )
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Send the new setpoint to the THM device."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+        # HA always passes the value in the entity's configured unit
+        # (Fahrenheit for this entity), so no conversion is needed before
+        # constructing the Temperature object.
+        try:
+            await self._device_helper().set_target_temperature(
+                Temperature(temperature, "F")
+            )
+            await self.coordinator.async_request_refresh()
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to set THM target temperature for %s: %s",
+                self._device_id, exc,
+            )
+
+    async def async_turn_on(self) -> None:
+        """Turn the thermostat on (resume Auto changeover)."""
+        await self.async_set_hvac_mode(HVACMode.AUTO)
+
+    async def async_turn_off(self) -> None:
+        """Turn the thermostat off (changeover -> Off)."""
+        await self.async_set_hvac_mode(HVACMode.OFF)

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
-  "requirements": ["pysensorlinx==0.3.0"],
-  "version": "2.4.0b2"
+  "requirements": ["pysensorlinx==0.4.0"],
+  "version": "2.5.0b1"
 }

--- a/custom_components/hbx_controls/number.py
+++ b/custom_components/hbx_controls/number.py
@@ -316,6 +316,17 @@ async def async_setup_entry(
                         building_id,
                     )
                 )
+
+            # ZON Auxiliary Setpoint (writes ``dhwT`` field).
+            if "aux_setpoint_target" in device_parameters and building_id:
+                entities.append(
+                    ZonAuxSetpointNumber(
+                        coordinator,
+                        device_id,
+                        device,
+                        building_id,
+                    )
+                )
     
     _LOGGER.debug("Adding %d number entities", len(entities))
     async_add_entities(entities)
@@ -2524,3 +2535,103 @@ class DHWDifferential(CoordinatorEntity, NumberEntity):
             delta = TemperatureDelta(value, "F")
         await device_helper.set_dhw_differential(delta)
         await self.coordinator.async_request_refresh()
+
+
+class ZonAuxSetpointNumber(CoordinatorEntity, NumberEntity):
+    """
+    Number entity backing the ZON ``dhwT`` (auxiliary setpoint) field.
+
+    Writes via :meth:`pysensorlinx.sensorlinx.ZonDevice.set_aux_setpoint`,
+    which encodes the value as an integer °F before PATCHing the device.
+    """
+
+    _attr_device_class = NumberDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.FAHRENHEIT
+    _attr_native_min_value = 33
+    _attr_native_max_value = 180
+    _attr_native_step = 1
+    _attr_mode = NumberMode.BOX
+    _attr_icon = "mdi:thermometer"
+
+    def __init__(
+        self,
+        coordinator: "HBXControlsDataUpdateCoordinator",
+        device_id: str,
+        device: dict,
+        building_id: str,
+    ) -> None:
+        """Initialize the ZON aux setpoint number."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._device = device
+        self._building_id = building_id
+
+        self._attr_unique_id = f"{device_id}_zon_aux_setpoint"
+        self._attr_name = f"{device.get('name', device_id)} Aux Setpoint"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "name": device.get("name", device_id),
+            "manufacturer": "HBX Controls",
+            "model": device.get("deviceType", "Unknown"),
+            "sw_version": device.get("firmware_version"),
+        }
+
+    def _params(self) -> dict | None:
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return None
+        return device.get("parameters") or {}
+
+    @property
+    def available(self) -> bool:
+        return (
+            self.coordinator.last_update_success
+            and self._params() is not None
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current ``dhwT`` value (°F)."""
+        params = self._params()
+        if not params:
+            return None
+        raw = params.get("aux_setpoint_target")
+        if raw is None:
+            return None
+        # Coordinator stores ``aux["target"]`` as-is; it can be a number or a
+        # Temperature-like object exposing ``.value`` / ``.to_fahrenheit()``.
+        if hasattr(raw, "to_fahrenheit"):
+            try:
+                return float(raw.to_fahrenheit())
+            except Exception:  # noqa: BLE001
+                pass
+        if hasattr(raw, "value"):
+            try:
+                return float(raw.value)
+            except Exception:  # noqa: BLE001
+                pass
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Send the new aux setpoint to the ZON device."""
+        from pysensorlinx.sensorlinx import ZonDevice
+
+        helper = ZonDevice(
+            self.coordinator.sensorlinx,
+            self._building_id,
+            self._device_id,
+        )
+        try:
+            await helper.set_aux_setpoint(Temperature(value, "F"))
+            await self.coordinator.async_request_refresh()
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to set ZON aux setpoint on %s: %s",
+                self._device_id, exc,
+            )

--- a/custom_components/hbx_controls/switch.py
+++ b/custom_components/hbx_controls/switch.py
@@ -213,6 +213,19 @@ async def async_setup_entry(
                         building_id,
                     )
                 )
+
+            # ZON app button switch (writes ``aBut`` field on ZON devices).
+            # Only created when the device exposes an enabled app button slot
+            # and we have a building id to address it with.
+            if device_parameters.get("app_button_enabled") and building_id:
+                entities.append(
+                    ZonAppButtonSwitch(
+                        coordinator,
+                        device_id,
+                        device,
+                        building_id,
+                    )
+                )
     
     _LOGGER.debug("Adding %d switch entities", len(entities))
     async_add_entities(entities)
@@ -1451,3 +1464,101 @@ class BackupOnlyTankTempSwitch(CoordinatorEntity, SwitchEntity):
         )
         await device_helper.set_backup_only_tank_temp("off")
         await self.coordinator.async_request_refresh()
+
+
+class ZonAppButtonSwitch(CoordinatorEntity, SwitchEntity):
+    """
+    Switch backing the ZON ``aBut`` (app button) field.
+
+    Toggling the switch flips the device's ``aBut`` integer between 0 and 1
+    via :meth:`pysensorlinx.sensorlinx.ZonDevice.set_app_button`. The HBX
+    cloud also flips the linked relay (typically index 12) as a side effect.
+
+    Only created when the device reports the app button slot is enabled.
+    """
+
+    _attr_icon = "mdi:gesture-tap-button"
+
+    def __init__(
+        self,
+        coordinator: "HBXControlsDataUpdateCoordinator",
+        device_id: str,
+        device: dict,
+        building_id: str,
+    ) -> None:
+        """Initialize the ZON app button switch."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._device = device
+        self._building_id = building_id
+
+        params = device.get("parameters") or {}
+        label = params.get("app_button_text") or "App Button"
+
+        self._attr_unique_id = f"{device_id}_zon_app_button"
+        self._attr_name = f"{device.get('name', device_id)} {label}"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "name": device.get("name", device_id),
+            "manufacturer": "HBX Controls",
+            "model": device.get("deviceType", "Unknown"),
+            "sw_version": device.get("firmware_version"),
+        }
+
+    def _params(self) -> dict | None:
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return None
+        return device.get("parameters") or {}
+
+    @property
+    def available(self) -> bool:
+        """Available when coordinator has fresh data and slot stays enabled."""
+        if not self.coordinator.last_update_success:
+            return False
+        params = self._params()
+        if not params:
+            return False
+        return bool(params.get("app_button_enabled"))
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the app button is currently activated."""
+        params = self._params()
+        if not params:
+            return None
+        return bool(params.get("app_button_activated"))
+
+    async def _set(self, enabled: bool) -> None:
+        from pysensorlinx.sensorlinx import ZonDevice
+
+        helper = ZonDevice(
+            self.coordinator.sensorlinx,
+            self._building_id,
+            self._device_id,
+        )
+        await helper.set_app_button(enabled)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Activate the ZON app button."""
+        try:
+            await self._set(True)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to enable ZON app button on %s: %s",
+                self._device_id, exc,
+            )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Deactivate the ZON app button."""
+        try:
+            await self._set(False)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to disable ZON app button on %s: %s",
+                self._device_id, exc,
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.4.0b2"
+version = "2.5.0b1"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_thm_climate.py
+++ b/tests/test_thm_climate.py
@@ -1,0 +1,215 @@
+"""Tests for the THM climate entity (2.5.0b1)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.climate import HVACAction, HVACMode
+from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant
+
+from custom_components.hbx_controls.climate import (
+    HBXControlsThmClimate,
+    async_setup_entry,
+)
+from custom_components.hbx_controls.const import DOMAIN
+
+from .conftest import MOCK_BUILDING_ID, MOCK_DEVICE_ID, make_coordinator_data, make_device
+
+
+THM_DEVICE_ID = "THM-001"
+
+
+def _thm_params(**overrides):
+    """Build a minimal set of THM parameters."""
+    params = {
+        "device_type": "THM",
+        "temperature_room": 71.5,
+        "target_temperature_room": 70.0,
+        "humidity": 42.0,
+        "hvac_mode": "heat",
+        "fan_mode": "off",
+        "thm_mode": "Air",
+        "is_off": False,
+        "is_heating": True,
+        "is_cooling": False,
+        "away_mode_activated": False,
+    }
+    params.update(overrides)
+    return params
+
+
+def _make_thm_device(**overrides):
+    return make_device(
+        device_id=THM_DEVICE_ID,
+        name="Hallway",
+        device_type="THM",
+        parameters=_thm_params(**overrides),
+    )
+
+
+def _coordinator_with_thm(mock_coordinator, **overrides):
+    device = _make_thm_device(**overrides)
+    mock_coordinator.data = make_coordinator_data(devices={THM_DEVICE_ID: device})
+    return device
+
+
+# ---------------------------------------------------------------------------
+# Setup entry
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_entry_creates_thm_climate(hass, mock_coordinator, mock_config_entry):
+    _coordinator_with_thm(mock_coordinator)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+
+    assert any(isinstance(e, HBXControlsThmClimate) for e in entities)
+
+
+async def test_setup_entry_skips_eco_for_thm_class(hass, mock_coordinator, mock_config_entry):
+    """ECO devices must NOT get a THM climate entity."""
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+    assert not any(isinstance(e, HBXControlsThmClimate) for e in entities)
+
+
+# ---------------------------------------------------------------------------
+# Read-side properties
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def thm_climate(mock_coordinator):
+    device = _coordinator_with_thm(mock_coordinator)
+    return HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+
+
+def test_current_temperature(thm_climate):
+    assert thm_climate.current_temperature == 71.5
+
+
+def test_target_temperature(thm_climate):
+    assert thm_climate.target_temperature == 70.0
+
+
+def test_current_humidity(thm_climate):
+    assert thm_climate.current_humidity == 42
+
+
+def test_hvac_mode_mapping(mock_coordinator):
+    for raw, expected in [
+        ("off", HVACMode.OFF),
+        ("heat", HVACMode.HEAT),
+        ("cool", HVACMode.COOL),
+        ("auto", HVACMode.AUTO),
+    ]:
+        device = _coordinator_with_thm(mock_coordinator, hvac_mode=raw)
+        ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+        assert ent.hvac_mode == expected
+
+
+def test_hvac_action_off(mock_coordinator):
+    device = _coordinator_with_thm(mock_coordinator, is_off=True, is_heating=False)
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.hvac_action == HVACAction.OFF
+
+
+def test_hvac_action_heating(thm_climate):
+    assert thm_climate.hvac_action == HVACAction.HEATING
+
+
+def test_hvac_action_cooling(mock_coordinator):
+    device = _coordinator_with_thm(mock_coordinator, is_heating=False, is_cooling=True)
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.hvac_action == HVACAction.COOLING
+
+
+def test_fan_mode(thm_climate):
+    assert thm_climate.fan_mode == "off"
+
+
+def test_preset_away(mock_coordinator):
+    device = _coordinator_with_thm(mock_coordinator, away_mode_activated=True)
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.preset_mode == "away"
+
+
+def test_preset_none(thm_climate):
+    assert thm_climate.preset_mode == "none"
+
+
+# ---------------------------------------------------------------------------
+# Write-side methods (mock the ThmDevice helper)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_thm():
+    with patch("custom_components.hbx_controls.climate.ThmDevice") as cls:
+        instance = MagicMock()
+        instance.set_hvac_mode = AsyncMock()
+        instance.set_fan_mode = AsyncMock()
+        instance.set_away_mode = AsyncMock()
+        instance.set_target_temperature = AsyncMock()
+        cls.return_value = instance
+        yield instance
+
+
+async def test_async_set_hvac_mode_writes_lib_str(thm_climate, patched_thm):
+    thm_climate.coordinator.async_request_refresh = AsyncMock()
+    await thm_climate.async_set_hvac_mode(HVACMode.COOL)
+    patched_thm.set_hvac_mode.assert_awaited_once_with("cool")
+    thm_climate.coordinator.async_request_refresh.assert_awaited()
+
+
+async def test_async_set_fan_mode(thm_climate, patched_thm):
+    thm_climate.coordinator.async_request_refresh = AsyncMock()
+    await thm_climate.async_set_fan_mode("intermittent")
+    patched_thm.set_fan_mode.assert_awaited_once_with("intermittent")
+
+
+async def test_async_set_fan_mode_rejects_unknown(thm_climate, patched_thm):
+    await thm_climate.async_set_fan_mode("turbo")
+    patched_thm.set_fan_mode.assert_not_awaited()
+
+
+async def test_async_set_preset_away(thm_climate, patched_thm):
+    thm_climate.coordinator.async_request_refresh = AsyncMock()
+    await thm_climate.async_set_preset_mode("away")
+    patched_thm.set_away_mode.assert_awaited_once_with(True)
+
+
+async def test_async_set_preset_none(thm_climate, patched_thm):
+    thm_climate.coordinator.async_request_refresh = AsyncMock()
+    await thm_climate.async_set_preset_mode("none")
+    patched_thm.set_away_mode.assert_awaited_once_with(False)
+
+
+async def test_async_set_temperature_uses_fahrenheit(thm_climate, patched_thm):
+    thm_climate.coordinator.async_request_refresh = AsyncMock()
+    await thm_climate.async_set_temperature(**{ATTR_TEMPERATURE: 72})
+    patched_thm.set_target_temperature.assert_awaited_once()
+    temp = patched_thm.set_target_temperature.await_args.args[0]
+    # Temperature object — verify the °F value is preserved
+    assert temp.to_fahrenheit() == 72
+
+
+async def test_async_turn_on_off(thm_climate, patched_thm):
+    thm_climate.coordinator.async_request_refresh = AsyncMock()
+    await thm_climate.async_turn_off()
+    await thm_climate.async_turn_on()
+    calls = [c.args[0] for c in patched_thm.set_hvac_mode.await_args_list]
+    assert calls == ["off", "auto"]
+
+
+async def test_write_swallows_setter_failure(thm_climate, patched_thm, caplog):
+    """A failing setter should log, not raise."""
+    patched_thm.set_hvac_mode.side_effect = RuntimeError("boom")
+    thm_climate.coordinator.async_request_refresh = AsyncMock()
+    await thm_climate.async_set_hvac_mode(HVACMode.HEAT)  # must not raise
+    assert "Failed to set THM HVAC mode" in caplog.text

--- a/tests/test_zon_app_button.py
+++ b/tests/test_zon_app_button.py
@@ -1,0 +1,113 @@
+"""Tests for the ZON app button switch (2.5.0b1)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hbx_controls.const import DOMAIN
+from custom_components.hbx_controls.switch import (
+    ZonAppButtonSwitch,
+    async_setup_entry,
+)
+
+from .conftest import MOCK_BUILDING_ID, make_coordinator_data, make_device
+
+
+ZON_DEVICE_ID = "ZON-001"
+
+
+def _zon_params(**overrides):
+    params = {
+        "device_type": "ZON",
+        "app_button_enabled": True,
+        "app_button_activated": False,
+        "app_button_text": "Boost",
+        "aux_setpoint_target": 120,
+    }
+    params.update(overrides)
+    return params
+
+
+def _make_zon_device(**overrides):
+    return make_device(
+        device_id=ZON_DEVICE_ID,
+        name="Zone Ctrl",
+        device_type="ZON",
+        parameters=_zon_params(**overrides),
+    )
+
+
+def _coordinator_with_zon(mock_coordinator, **overrides):
+    device = _make_zon_device(**overrides)
+    mock_coordinator.data = make_coordinator_data(devices={ZON_DEVICE_ID: device})
+    return device
+
+
+async def test_setup_entry_creates_app_button(hass, mock_coordinator, mock_config_entry):
+    _coordinator_with_zon(mock_coordinator)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+    assert any(isinstance(e, ZonAppButtonSwitch) for e in entities)
+
+
+async def test_setup_entry_skips_when_disabled(hass, mock_coordinator, mock_config_entry):
+    _coordinator_with_zon(mock_coordinator, app_button_enabled=False)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+    assert not any(isinstance(e, ZonAppButtonSwitch) for e in entities)
+
+
+@pytest.fixture
+def app_switch(mock_coordinator):
+    device = _coordinator_with_zon(mock_coordinator)
+    return ZonAppButtonSwitch(mock_coordinator, ZON_DEVICE_ID, device, MOCK_BUILDING_ID)
+
+
+def test_is_on_reflects_activated(app_switch):
+    assert app_switch.is_on is False
+
+
+def test_is_on_when_activated(mock_coordinator):
+    device = _coordinator_with_zon(mock_coordinator, app_button_activated=True)
+    sw = ZonAppButtonSwitch(mock_coordinator, ZON_DEVICE_ID, device, MOCK_BUILDING_ID)
+    assert sw.is_on is True
+
+
+def test_unavailable_when_slot_disabled(mock_coordinator):
+    device = _coordinator_with_zon(mock_coordinator, app_button_enabled=False)
+    sw = ZonAppButtonSwitch(mock_coordinator, ZON_DEVICE_ID, device, MOCK_BUILDING_ID)
+    mock_coordinator.last_update_success = True
+    assert sw.available is False
+
+
+@pytest.fixture
+def patched_zon():
+    with patch("pysensorlinx.sensorlinx.ZonDevice") as cls:
+        instance = MagicMock()
+        instance.set_app_button = AsyncMock()
+        cls.return_value = instance
+        yield instance
+
+
+async def test_turn_on_calls_set_app_button_true(app_switch, patched_zon):
+    app_switch.coordinator.async_request_refresh = AsyncMock()
+    await app_switch.async_turn_on()
+    patched_zon.set_app_button.assert_awaited_once_with(True)
+    app_switch.coordinator.async_request_refresh.assert_awaited()
+
+
+async def test_turn_off_calls_set_app_button_false(app_switch, patched_zon):
+    app_switch.coordinator.async_request_refresh = AsyncMock()
+    await app_switch.async_turn_off()
+    patched_zon.set_app_button.assert_awaited_once_with(False)
+
+
+async def test_turn_on_swallows_error(app_switch, patched_zon, caplog):
+    patched_zon.set_app_button.side_effect = RuntimeError("nope")
+    await app_switch.async_turn_on()
+    assert "Failed to enable ZON app button" in caplog.text

--- a/tests/test_zon_aux_setpoint.py
+++ b/tests/test_zon_aux_setpoint.py
@@ -1,0 +1,125 @@
+"""Tests for the ZON aux setpoint number entity (2.5.0b1)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hbx_controls.const import DOMAIN
+from custom_components.hbx_controls.number import (
+    ZonAuxSetpointNumber,
+    async_setup_entry,
+)
+
+from .conftest import MOCK_BUILDING_ID, make_coordinator_data, make_device
+
+
+ZON_DEVICE_ID = "ZON-001"
+
+
+def _zon_params(**overrides):
+    params = {
+        "device_type": "ZON",
+        "app_button_enabled": True,
+        "app_button_activated": False,
+        "aux_setpoint_target": 120,
+    }
+    params.update(overrides)
+    return params
+
+
+def _coordinator_with_zon(mock_coordinator, **overrides):
+    device = make_device(
+        device_id=ZON_DEVICE_ID,
+        name="Zone Ctrl",
+        device_type="ZON",
+        parameters=_zon_params(**overrides),
+    )
+    mock_coordinator.data = make_coordinator_data(devices={ZON_DEVICE_ID: device})
+    return device
+
+
+async def test_setup_entry_creates_aux_setpoint(hass, mock_coordinator, mock_config_entry):
+    _coordinator_with_zon(mock_coordinator)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+    assert any(isinstance(e, ZonAuxSetpointNumber) for e in entities)
+
+
+async def test_setup_entry_skips_when_no_aux(hass, mock_coordinator, mock_config_entry):
+    device = make_device(
+        device_id=ZON_DEVICE_ID,
+        device_type="ZON",
+        parameters={"device_type": "ZON", "app_button_enabled": False},
+    )
+    mock_coordinator.data = make_coordinator_data(devices={ZON_DEVICE_ID: device})
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+    assert not any(isinstance(e, ZonAuxSetpointNumber) for e in entities)
+
+
+@pytest.fixture
+def aux_number(mock_coordinator):
+    device = _coordinator_with_zon(mock_coordinator)
+    return ZonAuxSetpointNumber(
+        mock_coordinator, ZON_DEVICE_ID, device, MOCK_BUILDING_ID
+    )
+
+
+def test_native_value_int(aux_number):
+    assert aux_number.native_value == 120.0
+
+
+def test_native_value_temperature_object(mock_coordinator):
+    temp = MagicMock()
+    temp.to_fahrenheit = lambda: 122.0
+    device = _coordinator_with_zon(mock_coordinator, aux_setpoint_target=temp)
+    ent = ZonAuxSetpointNumber(mock_coordinator, ZON_DEVICE_ID, device, MOCK_BUILDING_ID)
+    assert ent.native_value == 122.0
+
+
+def test_native_value_value_attr(mock_coordinator):
+    fake = type("T", (), {"value": 118})()  # has .value but no .to_fahrenheit
+    device = _coordinator_with_zon(mock_coordinator, aux_setpoint_target=fake)
+    ent = ZonAuxSetpointNumber(mock_coordinator, ZON_DEVICE_ID, device, MOCK_BUILDING_ID)
+    assert ent.native_value == 118.0
+
+
+def test_native_value_none(mock_coordinator):
+    device = _coordinator_with_zon(mock_coordinator, aux_setpoint_target=None)
+    ent = ZonAuxSetpointNumber(mock_coordinator, ZON_DEVICE_ID, device, MOCK_BUILDING_ID)
+    assert ent.native_value is None
+
+
+def test_attributes(aux_number):
+    assert aux_number.native_min_value == 33
+    assert aux_number.native_max_value == 180
+    assert aux_number.native_step == 1
+
+
+@pytest.fixture
+def patched_zon():
+    with patch("pysensorlinx.sensorlinx.ZonDevice") as cls:
+        instance = MagicMock()
+        instance.set_aux_setpoint = AsyncMock()
+        cls.return_value = instance
+        yield instance
+
+
+async def test_set_native_value_calls_setter_with_temperature(aux_number, patched_zon):
+    aux_number.coordinator.async_request_refresh = AsyncMock()
+    await aux_number.async_set_native_value(125)
+    patched_zon.set_aux_setpoint.assert_awaited_once()
+    arg = patched_zon.set_aux_setpoint.await_args.args[0]
+    assert arg.to_fahrenheit() == 125
+    aux_number.coordinator.async_request_refresh.assert_awaited()
+
+
+async def test_set_native_value_swallows_error(aux_number, patched_zon, caplog):
+    patched_zon.set_aux_setpoint.side_effect = RuntimeError("oops")
+    await aux_number.async_set_native_value(125)
+    assert "Failed to set ZON aux setpoint" in caplog.text


### PR DESCRIPTION
## 2.5.0b1 — THM/ZON write support 🎛️

First write-capable beta for THM thermostats and ZON zone controllers, backed
by [pysensorlinx 0.4.0](https://pypi.org/project/pysensorlinx/0.4.0/).

### New entities

**For each THM device:**
- `climate.<thm>` — HVAC mode (Off / Heat / Cool / Auto), target temperature,
  fan mode (Off / On / Intermittent), Away preset.

**For each ZON device:**
- `switch.<zon>_<app_button_label>` — toggles the device-side app button (`aBut`).
- `number.<zon>_aux_setpoint` — writes the auxiliary setpoint (`dhwT`, °F).

### Field mapping (confirmed from eelton's data dumps)

| Surface | HBX raw field |
|---|---|
| THM HVAC mode | `cngOvr` (0=Auto, 1=Heat, 2=Cool, 3=Off) |
| THM Away preset | `away` (0/1) |
| THM Fan mode | `fnMode` (0=Off, 1=On, 2=Intermittent) |
| THM Setpoint | nested `target.value` (°F int) — *speculative shape*, see below |
| ZON App button | `aBut` (0/1) |
| ZON Aux setpoint | `dhwT` (°F int) |

The target-temperature payload shape is the only inferred one — eelton's read
dumps showed `target.value` was the only field that changed when he moved a
setpoint, so that's what we PATCH. If HBX rejects this, we'll iterate in
0.4.1.

### Tests

37 new unit tests covering platform setup, read-side state mapping, and
write-side delegation. Full suite green: **340 passed**.

### Validation plan

Eelton (issue #12) — once installed, run through:
- THM: cycle HVAC mode (Off → Heat → Cool → Auto → Off); set target +5°F then
  back; toggle Away on/off; cycle Fan Off → On → Intermittent.
- ZON: toggle App Button; bump Aux Setpoint by 2°F then back.

Each step should be reflected in the HBX mobile app within ~30s.

---

Closes the THM/ZON-write track of #12.
