### PR TITLE
fix: 2.5.0b2 - THM target temp + ZON app button flicker

### DIFF
--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
-  "requirements": ["pysensorlinx==0.4.0"],
-  "version": "2.5.0b1"
+  "requirements": ["pysensorlinx==0.4.1"],
+  "version": "2.5.0b2"
 }

--- a/custom_components/hbx_controls/switch.py
+++ b/custom_components/hbx_controls/switch.py
@@ -1491,6 +1491,11 @@ class ZonAppButtonSwitch(CoordinatorEntity, SwitchEntity):
         self._device_id = device_id
         self._device = device
         self._building_id = building_id
+        # Optimistic state used between a successful write and the first
+        # coordinator refresh that confirms the new state. Avoids the 1-2s
+        # flicker caused by HBX returning the stale value immediately after
+        # a write.
+        self._pending: bool | None = None
 
         params = device.get("parameters") or {}
         label = params.get("app_button_text") or "App Button"
@@ -1526,11 +1531,21 @@ class ZonAppButtonSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool | None:
-        """Return whether the app button is currently activated."""
+        """Return whether the app button is currently activated.
+
+        Returns the optimistic ``_pending`` state when a write has been
+        issued but the coordinator hasn't yet observed the new value, to
+        suppress the brief flicker caused by HBX returning the stale value
+        immediately after a write.
+        """
         params = self._params()
-        if not params:
-            return None
-        return bool(params.get("app_button_activated"))
+        actual = bool(params.get("app_button_activated")) if params else None
+        if self._pending is not None:
+            if actual is not None and actual == self._pending:
+                self._pending = None
+                return actual
+            return self._pending
+        return actual
 
     async def _set(self, enabled: bool) -> None:
         from pysensorlinx.sensorlinx import ZonDevice
@@ -1541,6 +1556,8 @@ class ZonAppButtonSwitch(CoordinatorEntity, SwitchEntity):
             self._device_id,
         )
         await helper.set_app_button(enabled)
+        self._pending = enabled
+        self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b1"
+version = "2.5.0b2"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_zon_app_button.py
+++ b/tests/test_zon_app_button.py
@@ -65,7 +65,10 @@ async def test_setup_entry_skips_when_disabled(hass, mock_coordinator, mock_conf
 @pytest.fixture
 def app_switch(mock_coordinator):
     device = _coordinator_with_zon(mock_coordinator)
-    return ZonAppButtonSwitch(mock_coordinator, ZON_DEVICE_ID, device, MOCK_BUILDING_ID)
+    sw = ZonAppButtonSwitch(mock_coordinator, ZON_DEVICE_ID, device, MOCK_BUILDING_ID)
+    # Bypass HA's `hass` requirement when invoking optimistic state writes.
+    sw.async_write_ha_state = MagicMock()
+    return sw
 
 
 def test_is_on_reflects_activated(app_switch):
@@ -111,3 +114,40 @@ async def test_turn_on_swallows_error(app_switch, patched_zon, caplog):
     patched_zon.set_app_button.side_effect = RuntimeError("nope")
     await app_switch.async_turn_on()
     assert "Failed to enable ZON app button" in caplog.text
+
+
+async def test_optimistic_state_after_turn_on(app_switch, patched_zon, mock_coordinator):
+    """is_on returns the requested state until coordinator confirms it."""
+    app_switch.coordinator.async_request_refresh = AsyncMock()
+    # Coordinator initially reports OFF (matching device fixture).
+    assert app_switch.is_on is False
+
+    await app_switch.async_turn_on()
+
+    # Coordinator hasn't refreshed yet → still reports OFF, but is_on
+    # should now return the optimistic ON to suppress the flicker.
+    assert app_switch.is_on is True
+
+    # Coordinator catches up → optimistic state clears, returns coordinator value.
+    _coordinator_with_zon(mock_coordinator, app_button_activated=True)
+    # Re-bind device pointer (coordinator data was replaced).
+    assert app_switch.is_on is True
+    assert app_switch._pending is None
+
+
+async def test_optimistic_state_after_turn_off(app_switch, patched_zon, mock_coordinator):
+    """Optimistic state survives a stale-on coordinator refresh."""
+    _coordinator_with_zon(mock_coordinator, app_button_activated=True)
+    app_switch.coordinator.async_request_refresh = AsyncMock()
+    assert app_switch.is_on is True
+
+    await app_switch.async_turn_off()
+
+    # Stale coordinator data still says ON; is_on must report optimistic OFF.
+    assert app_switch.is_on is False
+    assert app_switch._pending is False
+
+    # Coordinator catches up to OFF → optimistic clears.
+    _coordinator_with_zon(mock_coordinator, app_button_activated=False)
+    assert app_switch.is_on is False
+    assert app_switch._pending is None


### PR DESCRIPTION
## Summary

Two follow-up fixes on top of `2.5.0b1`, both surfaced by @eelton's testing in #12.

### THM target temperature now actually writes
`pysensorlinx 0.4.1` switches the heat / cool setpoint write to the top-level `rmT` / `rmCT` fields. The previous `target.value` payload was server-derived and silently no-op'd on PATCH (read response shape != write response shape).

`ThmDevice.set_target_temperature` now reads `target.type` (`"heat"` / `"cooling"`) to dispatch to the right field, and rejects writes when the device is off.

### ZON app button no longer flickers
Toggle → off → snaps back to on for ~3s → off was a race between the post-write `async_request_refresh()` and HBX's cloud propagation delay. `ZonAppButtonSwitch` now holds an optimistic `_pending` state until coordinator data agrees with it, suppressing the flicker.

## Files
- `manifest.json`: 2.5.0b1 → 2.5.0b2, `pysensorlinx==0.4.1`
- `pyproject.toml`: 2.5.0b1 → 2.5.0b2
- `switch.py`: optimistic-state pattern in `ZonAppButtonSwitch`
- `tests/test_zon_app_button.py`: 2 new tests for optimistic state across stale coordinator refresh

## Testing
- `pytest tests/`: 342 passed (340 baseline + 2 new optimistic-state tests)
- `pysensorlinx 0.4.1` already shipped to PyPI via #23 → release workflow
- Field mapping confirmed against eelton's before/after JSON dumps from the HBX API
