### PR TITLE
Add ZON per-zone demand binary sensors (2.5.0b3)

### DIFF
--- a/custom_components/hbx_controls/binary_sensor.py
+++ b/custom_components/hbx_controls/binary_sensor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pysensorlinx import DEVICE_TYPE_ZON
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -98,6 +100,29 @@ async def async_setup_entry(
                         "Running",
                     )
                 )
+
+            # Create per-zone demand binary sensors for ZON controllers.
+            dtype = (device_parameters.get("device_type") or device.get("deviceType") or "").upper()
+            if dtype == DEVICE_TYPE_ZON:
+                relays = device_parameters.get("relays") or []
+                relay_types = device_parameters.get("relay_types") or []
+                # Best-effort: only create entities for slots that look
+                # configured. Relay slots with relay_type == 0 are presumed
+                # disabled / unwired; if relay_types is missing entirely,
+                # fall back to all 16 slots so we don't silently skip
+                # everything on devices that don't report the array.
+                for idx in range(len(relays)):
+                    rtype = relay_types[idx] if idx < len(relay_types) else None
+                    if rtype is not None and rtype == 0:
+                        continue
+                    entities.append(
+                        ZonRelayDemandBinarySensor(
+                            coordinator,
+                            device_id,
+                            device,
+                            idx,
+                        )
+                    )
     else:
         _LOGGER.debug("No coordinator data or devices found")
     
@@ -329,3 +354,66 @@ class BackupBinarySensor(CoordinatorEntity, BinarySensorEntity):
             
         parameters = device.get("parameters", {})
         return parameters.get("backup_state") is not None
+
+
+class ZonRelayDemandBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """
+    Per-zone demand binary sensor for a ZON zone controller.
+
+    Reads the boolean state of one slot in the ZON's ``relays`` array. A
+    relay turning on reflects the controller energizing that zone's
+    pump/valve in response to a thermostat demand.
+
+    Slots are 0-indexed internally; entity names are 1-indexed for
+    user-friendliness ("Zone 1" through "Zone 16").
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_icon = "mdi:pipe-valve"
+
+    def __init__(
+        self,
+        coordinator: HBXControlsDataUpdateCoordinator,
+        device_id: str,
+        device: dict[str, Any],
+        index: int,
+    ) -> None:
+        """Initialize the ZON relay demand binary sensor."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._device = device
+        self._index = index
+
+        self._attr_unique_id = f"{device_id}_zon_relay_{index}"
+        self._attr_name = f"{device.get('name', device_id)} Zone {index + 1}"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "name": device.get("name", device_id),
+            "manufacturer": "HBX Controls",
+            "model": device.get("deviceType", "Unknown"),
+            "sw_version": device.get("firmware_version"),
+        }
+
+    def _relays(self) -> list[bool]:
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return []
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return []
+        return device.get("parameters", {}).get("relays") or []
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether this zone's relay is currently energized."""
+        relays = self._relays()
+        if self._index >= len(relays):
+            return None
+        return bool(relays[self._index])
+
+    @property
+    def available(self) -> bool:
+        """Available while the coordinator reports a relay slot for this index."""
+        if not self.coordinator.last_update_success:
+            return False
+        return self._index < len(self._relays())

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
   "requirements": ["pysensorlinx==0.4.1"],
-  "version": "2.5.0b2"
+  "version": "2.5.0b3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b2"
+version = "2.5.0b3"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_zon_relay_sensors.py
+++ b/tests/test_zon_relay_sensors.py
@@ -1,0 +1,125 @@
+"""Tests for the ZON relay demand binary sensors (2.5.0b3)."""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.hbx_controls.binary_sensor import (
+    ZonRelayDemandBinarySensor,
+    async_setup_entry,
+)
+from custom_components.hbx_controls.const import DOMAIN
+
+from .conftest import MOCK_BUILDING_ID, make_coordinator_data, make_device
+
+
+ZON_DEVICE_ID = "ZON-001"
+
+
+def _zon_params(**overrides):
+    params = {
+        "device_type": "ZON",
+        "relays": [False] * 16,
+        "relay_types": [1, 1, 1] + [0] * 13,
+        "app_button_enabled": False,
+    }
+    params.update(overrides)
+    return params
+
+
+def _make_zon_device(**overrides):
+    return make_device(
+        device_id=ZON_DEVICE_ID,
+        name="Zone Ctrl",
+        device_type="ZON",
+        parameters=_zon_params(**overrides),
+    )
+
+
+def _coordinator_with_zon(mock_coordinator, **overrides):
+    device = _make_zon_device(**overrides)
+    mock_coordinator.data = make_coordinator_data(devices={ZON_DEVICE_ID: device})
+    return device
+
+
+async def test_setup_creates_one_entity_per_configured_relay(
+    hass, mock_coordinator, mock_config_entry
+):
+    """Only slots with non-zero relay_type get entities."""
+    _coordinator_with_zon(mock_coordinator)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+
+    relay_entities = [e for e in entities if isinstance(e, ZonRelayDemandBinarySensor)]
+    assert len(relay_entities) == 3
+    # Indices 0..2 are configured.
+    assert sorted(e._index for e in relay_entities) == [0, 1, 2]
+
+
+async def test_setup_falls_back_to_all_slots_when_relay_types_missing(
+    hass, mock_coordinator, mock_config_entry
+):
+    """When relay_types is empty/missing, expose every slot we have data for."""
+    _coordinator_with_zon(mock_coordinator, relay_types=[])
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+
+    relay_entities = [e for e in entities if isinstance(e, ZonRelayDemandBinarySensor)]
+    assert len(relay_entities) == 16
+
+
+async def test_setup_skips_when_relays_array_missing(
+    hass, mock_coordinator, mock_config_entry
+):
+    """Devices without a relays array yield no relay sensors."""
+    _coordinator_with_zon(mock_coordinator, relays=[])
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+
+    assert not any(isinstance(e, ZonRelayDemandBinarySensor) for e in entities)
+
+
+def test_is_on_reflects_relay_state(mock_coordinator):
+    """is_on tracks the boolean at the entity's index in the relays array."""
+    device = _coordinator_with_zon(
+        mock_coordinator,
+        relays=[True, False, True] + [False] * 13,
+    )
+    sw0 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 0)
+    sw1 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 1)
+    sw2 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 2)
+
+    assert sw0.is_on is True
+    assert sw1.is_on is False
+    assert sw2.is_on is True
+
+
+def test_is_on_handles_short_relay_array(mock_coordinator):
+    """When relays is shorter than expected, is_on returns None for missing slots."""
+    device = _coordinator_with_zon(
+        mock_coordinator,
+        relays=[True, False],
+    )
+    sw5 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 5)
+    assert sw5.is_on is None
+
+
+def test_unavailable_when_index_out_of_range(mock_coordinator):
+    """Entities for indices that disappear from coordinator data go unavailable."""
+    device = _coordinator_with_zon(mock_coordinator, relays=[True])
+    sw5 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 5)
+    mock_coordinator.last_update_success = True
+    assert sw5.available is False
+
+
+def test_naming_is_one_indexed(mock_coordinator):
+    """Internal 0-indexed slots surface as 1-indexed names."""
+    device = _coordinator_with_zon(mock_coordinator)
+    sw = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 0)
+    assert sw._attr_name.endswith("Zone 1")
+    assert sw._attr_unique_id.endswith("_zon_relay_0")


### PR DESCRIPTION
## Summary

Adds per-zone demand binary sensors for ZON zone controllers, fulfilling the "let me see which zones are calling for heat" piece of the eelton feedback in #12.

One `binary_sensor.<zon>_zone_<n>` per configured relay slot (1-indexed for display). Reads `parameters["relays"][i]` (already in the coordinator since 2.4.0).

## Detection heuristic

- Skip slot `i` when `relay_types[i] == 0` (treated as unwired).
- If `relay_types` is missing/empty, expose all 16 slots so we don't silently drop everything.

This is a guess. If too many or too few zones show up for a real device, we'll tune the filter.

## Tests

- 7 new tests in `tests/test_zon_relay_sensors.py` covering: filtering by relay_types, fallback when missing, is_on tracking the relay array, short-array handling, availability, and 1-indexed naming.
- Full suite: 349 passed (was 342).

## Out of scope

- THM enable-schedule toggle and humidity mode — waiting on before/after dumps from eelton to confirm the field names.
- ZON aux setpoint follow-up — eelton reported no effect on his hardware; deferred.

Closes part of #12.
