### PR TITLE
feat: 2.5.0b4 - THM schedule + humidity write entities

### DIFF
--- a/custom_components/hbx_controls/coordinator.py
+++ b/custom_components/hbx_controls/coordinator.py
@@ -180,6 +180,21 @@ async def _extract_thm_parameters(device_helper, device: dict) -> dict[str, Any]
     except Exception as exc:  # noqa: BLE001
         _LOGGER.debug("THM away mode: %s", exc)
 
+    # Schedule + humidity raw fields. pysensorlinx 0.5.0 added setters
+    # for these but no getters yet, so we read them straight from the
+    # device dict. Field names confirmed from THM-0600 dumps 2026-04-28.
+    if "pgmble" in device:
+        parameters["schedule_enabled"] = bool(device.get("pgmble"))
+    if "useHum" in device:
+        humidity_mode = {0: "off", 1: "on", 2: "auto"}.get(device.get("useHum"))
+        if humidity_mode is not None:
+            parameters["humidity_mode"] = humidity_mode
+    if "hmT" in device:
+        try:
+            parameters["humidity_target"] = int(device.get("hmT"))
+        except (TypeError, ValueError):
+            _LOGGER.debug("THM humidity target not an int: %r", device.get("hmT"))
+
     return parameters
 
 

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
-  "requirements": ["pysensorlinx==0.4.1"],
-  "version": "2.5.0b3"
+  "requirements": ["pysensorlinx==0.5.0"],
+  "version": "2.5.0b4"
 }

--- a/custom_components/hbx_controls/number.py
+++ b/custom_components/hbx_controls/number.py
@@ -327,6 +327,17 @@ async def async_setup_entry(
                         building_id,
                     )
                 )
+
+            # THM Humidity Target (writes ``hmT`` field).
+            if "humidity_target" in device_parameters and building_id:
+                entities.append(
+                    ThmHumidityTargetNumber(
+                        coordinator,
+                        device_id,
+                        device,
+                        building_id,
+                    )
+                )
     
     _LOGGER.debug("Adding %d number entities", len(entities))
     async_add_entities(entities)
@@ -2635,3 +2646,99 @@ class ZonAuxSetpointNumber(CoordinatorEntity, NumberEntity):
                 "Failed to set ZON aux setpoint on %s: %s",
                 self._device_id, exc,
             )
+
+class ThmHumidityTargetNumber(CoordinatorEntity, NumberEntity):
+    """
+    Number entity backing the THM ``hmT`` (humidity target %) field.
+
+    Writes via :meth:`pysensorlinx.sensorlinx.ThmDevice.set_humidity_target`
+    which PATCHes ``hmT`` as an integer percent (0-100). Field mapping
+    confirmed via paired before/after THM-0600 dumps on 2026-04-28.
+    """
+
+    _attr_native_unit_of_measurement = "%"
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 1
+    _attr_mode = NumberMode.BOX
+    _attr_icon = "mdi:water-percent"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: "HBXControlsDataUpdateCoordinator",
+        device_id: str,
+        device: dict,
+        building_id: str,
+    ) -> None:
+        """Initialize the THM humidity target number."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._device = device
+        self._building_id = building_id
+        self._pending: int | None = None
+
+        self._attr_unique_id = f"{device_id}_thm_humidity_target"
+        self._attr_name = f"{device.get('name', device_id)} Humidity Target"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "name": device.get("name", device_id),
+            "manufacturer": "HBX Controls",
+            "model": device.get("deviceType", "Unknown"),
+            "sw_version": device.get("firmware_version"),
+        }
+
+    def _params(self) -> dict | None:
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return None
+        return device.get("parameters") or {}
+
+    @property
+    def available(self) -> bool:
+        if not self.coordinator.last_update_success:
+            return False
+        params = self._params()
+        return params is not None and "humidity_target" in params
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current humidity target in percent."""
+        params = self._params()
+        actual = params.get("humidity_target") if params else None
+        if self._pending is not None:
+            if actual is not None and int(actual) == self._pending:
+                self._pending = None
+                return float(actual)
+            return float(self._pending)
+        if actual is None:
+            return None
+        try:
+            return float(actual)
+        except (TypeError, ValueError):
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Send the new humidity target to the THM device."""
+        from pysensorlinx.sensorlinx import ThmDevice
+
+        helper = ThmDevice(
+            self.coordinator.sensorlinx,
+            self._building_id,
+            self._device_id,
+        )
+        target = int(round(value))
+        try:
+            await helper.set_humidity_target(target)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to set THM humidity target on %s: %s",
+                self._device_id, exc,
+            )
+            return
+        self._pending = target
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/hbx_controls/select.py
+++ b/custom_components/hbx_controls/select.py
@@ -48,6 +48,17 @@ async def async_setup_entry(
                         building_id,
                     )
                 )
+
+            # THM humidity mode select (writes ``useHum`` field).
+            if "humidity_mode" in device_parameters and building_id:
+                entities.append(
+                    ThmHumidityModeSelect(
+                        coordinator,
+                        device_id,
+                        device,
+                        building_id,
+                    )
+                )
     
     _LOGGER.debug("Adding %d select entities", len(entities))
     async_add_entities(entities)
@@ -119,4 +130,97 @@ class HvacModePrioritySelect(CoordinatorEntity, SelectEntity):
             self._device_id,
         )
         await device_helper.set_hvac_mode_priority(option)
+        await self.coordinator.async_request_refresh()
+
+
+class ThmHumidityModeSelect(CoordinatorEntity, SelectEntity):
+    """
+    Select entity backing the THM ``useHum`` field (humidity mode).
+
+    Three options:
+
+    * ``off`` (``useHum`` = 0): humidity control is disabled.
+    * ``on`` (``useHum`` = 1): runs continuously toward the humidity target.
+    * ``auto`` (``useHum`` = 2): THM picks based on conditions.
+
+    Field mapping confirmed via paired before/after THM-0600 dumps on
+    2026-04-28.
+    """
+
+    _attr_options = ["off", "on", "auto"]
+    _attr_icon = "mdi:water-percent"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: HBXControlsDataUpdateCoordinator,
+        device_id: str,
+        device: dict[str, Any],
+        building_id: str,
+    ) -> None:
+        """Initialize the THM humidity mode select."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._device = device
+        self._building_id = building_id
+        self._pending: str | None = None
+
+        self._attr_unique_id = f"{device_id}_thm_humidity_mode"
+        self._attr_name = f"{device.get('name', device_id)} Humidity Mode"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "name": device.get("name", device_id),
+            "manufacturer": "HBX Controls",
+            "model": device.get("deviceType", "Unknown"),
+            "sw_version": device.get("firmware_version"),
+        }
+
+    def _params(self) -> dict | None:
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return None
+        return device.get("parameters") or {}
+
+    @property
+    def available(self) -> bool:
+        """Available when coordinator data carries a humidity_mode value."""
+        if not self.coordinator.last_update_success:
+            return False
+        params = self._params()
+        return params is not None and "humidity_mode" in params
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently selected humidity mode."""
+        params = self._params()
+        actual = params.get("humidity_mode") if params else None
+        if self._pending is not None:
+            if actual is not None and actual == self._pending:
+                self._pending = None
+                return actual
+            return self._pending
+        return actual
+
+    async def async_select_option(self, option: str) -> None:
+        """Write the new humidity mode to the THM."""
+        from pysensorlinx.sensorlinx import ThmDevice
+
+        helper = ThmDevice(
+            self.coordinator.sensorlinx,
+            self._building_id,
+            self._device_id,
+        )
+        try:
+            await helper.set_humidity_mode(option)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to set THM humidity mode on %s: %s",
+                self._device_id, exc,
+            )
+            return
+        self._pending = option
+        self.async_write_ha_state()
         await self.coordinator.async_request_refresh()

--- a/custom_components/hbx_controls/switch.py
+++ b/custom_components/hbx_controls/switch.py
@@ -226,6 +226,19 @@ async def async_setup_entry(
                         building_id,
                     )
                 )
+
+            # THM schedule-enable switch (writes ``pgmble`` field on THM
+            # devices). Created whenever the THM exposes a schedule_enabled
+            # value in its parameters dict.
+            if "schedule_enabled" in device_parameters and building_id:
+                entities.append(
+                    ThmScheduleEnableSwitch(
+                        coordinator,
+                        device_id,
+                        device,
+                        building_id,
+                    )
+                )
     
     _LOGGER.debug("Adding %d switch entities", len(entities))
     async_add_entities(entities)
@@ -1577,5 +1590,105 @@ class ZonAppButtonSwitch(CoordinatorEntity, SwitchEntity):
         except Exception as exc:  # noqa: BLE001
             _LOGGER.error(
                 "Failed to disable ZON app button on %s: %s",
+                self._device_id, exc,
+            )
+
+
+class ThmScheduleEnableSwitch(CoordinatorEntity, SwitchEntity):
+    """
+    Switch backing the THM ``pgmble`` (program enable) field.
+
+    Toggling the switch flips the device's ``pgmble`` integer between 0
+    and 1 via :meth:`pysensorlinx.sensorlinx.ThmDevice.set_schedule_enabled`.
+    When enabled, the THM's on-device weekday/weekend program drives the
+    setpoint; when disabled, the manual setpoint is held.
+    """
+
+    _attr_icon = "mdi:calendar-clock"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: "HBXControlsDataUpdateCoordinator",
+        device_id: str,
+        device: dict,
+        building_id: str,
+    ) -> None:
+        """Initialize the THM schedule-enable switch."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._device = device
+        self._building_id = building_id
+        self._pending: bool | None = None
+
+        self._attr_unique_id = f"{device_id}_thm_schedule_enabled"
+        self._attr_name = f"{device.get('name', device_id)} Schedule"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "name": device.get("name", device_id),
+            "manufacturer": "HBX Controls",
+            "model": device.get("deviceType", "Unknown"),
+            "sw_version": device.get("firmware_version"),
+        }
+
+    def _params(self) -> dict | None:
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+        device = self.coordinator.data["devices"].get(self._device_id)
+        if not device:
+            return None
+        return device.get("parameters") or {}
+
+    @property
+    def available(self) -> bool:
+        """Available when coordinator has fresh data and the field is present."""
+        if not self.coordinator.last_update_success:
+            return False
+        params = self._params()
+        return params is not None and "schedule_enabled" in params
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the on-device schedule is enabled."""
+        params = self._params()
+        actual = bool(params.get("schedule_enabled")) if params else None
+        if self._pending is not None:
+            if actual is not None and actual == self._pending:
+                self._pending = None
+                return actual
+            return self._pending
+        return actual
+
+    async def _set(self, enabled: bool) -> None:
+        from pysensorlinx.sensorlinx import ThmDevice
+
+        helper = ThmDevice(
+            self.coordinator.sensorlinx,
+            self._building_id,
+            self._device_id,
+        )
+        await helper.set_schedule_enabled(enabled)
+        self._pending = enabled
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the THM on-device schedule."""
+        try:
+            await self._set(True)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to enable THM schedule on %s: %s",
+                self._device_id, exc,
+            )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the THM on-device schedule."""
+        try:
+            await self._set(False)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to disable THM schedule on %s: %s",
                 self._device_id, exc,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b3"
+version = "2.5.0b4"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_thm_schedule_humidity.py
+++ b/tests/test_thm_schedule_humidity.py
@@ -1,0 +1,396 @@
+"""Tests for THM schedule + humidity entities (2.5.0b4)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hbx_controls.const import DOMAIN
+from custom_components.hbx_controls.number import (
+    ThmHumidityTargetNumber,
+    async_setup_entry as number_async_setup_entry,
+)
+from custom_components.hbx_controls.select import (
+    ThmHumidityModeSelect,
+    async_setup_entry as select_async_setup_entry,
+)
+from custom_components.hbx_controls.switch import (
+    ThmScheduleEnableSwitch,
+    async_setup_entry as switch_async_setup_entry,
+)
+
+from .conftest import MOCK_BUILDING_ID, make_coordinator_data, make_device
+
+
+THM_DEVICE_ID = "THM-001"
+
+
+def _thm_params(**overrides):
+    params = {
+        "device_type": "THM",
+        "schedule_enabled": False,
+        "humidity_mode": "off",
+        "humidity_target": 40,
+    }
+    params.update(overrides)
+    return params
+
+
+def _make_thm_device(**overrides):
+    return make_device(
+        device_id=THM_DEVICE_ID,
+        name="Living Room",
+        device_type="THM",
+        parameters=_thm_params(**overrides),
+    )
+
+
+def _coordinator_with_thm(mock_coordinator, **overrides):
+    device = _make_thm_device(**overrides)
+    mock_coordinator.data = make_coordinator_data(devices={THM_DEVICE_ID: device})
+    return device
+
+
+# ---------------------------------------------------------------------------
+# Setup tests — entities are wired up when the right keys are present
+# ---------------------------------------------------------------------------
+
+async def test_setup_creates_schedule_switch(hass, mock_coordinator, mock_config_entry):
+    _coordinator_with_thm(mock_coordinator)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await switch_async_setup_entry(hass, mock_config_entry, entities.extend)
+    assert any(isinstance(e, ThmScheduleEnableSwitch) for e in entities)
+
+
+async def test_setup_skips_schedule_switch_without_field(
+    hass, mock_coordinator, mock_config_entry
+):
+    device = _make_thm_device()
+    device["parameters"].pop("schedule_enabled")
+    mock_coordinator.data = make_coordinator_data(devices={THM_DEVICE_ID: device})
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await switch_async_setup_entry(hass, mock_config_entry, entities.extend)
+    assert not any(isinstance(e, ThmScheduleEnableSwitch) for e in entities)
+
+
+async def test_setup_creates_humidity_mode_select(
+    hass, mock_coordinator, mock_config_entry
+):
+    _coordinator_with_thm(mock_coordinator)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await select_async_setup_entry(hass, mock_config_entry, entities.extend)
+    assert any(isinstance(e, ThmHumidityModeSelect) for e in entities)
+
+
+async def test_setup_skips_humidity_mode_select_without_field(
+    hass, mock_coordinator, mock_config_entry
+):
+    device = _make_thm_device()
+    device["parameters"].pop("humidity_mode")
+    mock_coordinator.data = make_coordinator_data(devices={THM_DEVICE_ID: device})
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await select_async_setup_entry(hass, mock_config_entry, entities.extend)
+    assert not any(isinstance(e, ThmHumidityModeSelect) for e in entities)
+
+
+async def test_setup_creates_humidity_target_number(
+    hass, mock_coordinator, mock_config_entry
+):
+    _coordinator_with_thm(mock_coordinator)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await number_async_setup_entry(hass, mock_config_entry, entities.extend)
+    assert any(isinstance(e, ThmHumidityTargetNumber) for e in entities)
+
+
+async def test_setup_skips_humidity_target_number_without_field(
+    hass, mock_coordinator, mock_config_entry
+):
+    device = _make_thm_device()
+    device["parameters"].pop("humidity_target")
+    mock_coordinator.data = make_coordinator_data(devices={THM_DEVICE_ID: device})
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await number_async_setup_entry(hass, mock_config_entry, entities.extend)
+    assert not any(isinstance(e, ThmHumidityTargetNumber) for e in entities)
+
+
+# ---------------------------------------------------------------------------
+# Schedule switch
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def schedule_switch(mock_coordinator):
+    device = _coordinator_with_thm(mock_coordinator)
+    sw = ThmScheduleEnableSwitch(
+        mock_coordinator, THM_DEVICE_ID, device, MOCK_BUILDING_ID
+    )
+    sw.async_write_ha_state = MagicMock()
+    return sw
+
+
+@pytest.fixture
+def patched_thm():
+    with patch("pysensorlinx.sensorlinx.ThmDevice") as cls:
+        instance = MagicMock()
+        instance.set_schedule_enabled = AsyncMock()
+        instance.set_humidity_mode = AsyncMock()
+        instance.set_humidity_target = AsyncMock()
+        cls.return_value = instance
+        yield instance
+
+
+def test_schedule_is_on_reflects_field(schedule_switch):
+    assert schedule_switch.is_on is False
+
+
+def test_schedule_is_on_when_enabled(mock_coordinator):
+    device = _coordinator_with_thm(mock_coordinator, schedule_enabled=True)
+    sw = ThmScheduleEnableSwitch(
+        mock_coordinator, THM_DEVICE_ID, device, MOCK_BUILDING_ID
+    )
+    assert sw.is_on is True
+
+
+def test_schedule_unavailable_when_field_missing(mock_coordinator):
+    device = _make_thm_device()
+    device["parameters"].pop("schedule_enabled")
+    mock_coordinator.data = make_coordinator_data(devices={THM_DEVICE_ID: device})
+    sw = ThmScheduleEnableSwitch(
+        mock_coordinator, THM_DEVICE_ID, device, MOCK_BUILDING_ID
+    )
+    mock_coordinator.last_update_success = True
+    assert sw.available is False
+
+
+async def test_schedule_turn_on_calls_setter(schedule_switch, patched_thm):
+    schedule_switch.coordinator.async_request_refresh = AsyncMock()
+    await schedule_switch.async_turn_on()
+    patched_thm.set_schedule_enabled.assert_awaited_once_with(True)
+    schedule_switch.coordinator.async_request_refresh.assert_awaited()
+
+
+async def test_schedule_turn_off_calls_setter(schedule_switch, patched_thm):
+    schedule_switch.coordinator.async_request_refresh = AsyncMock()
+    await schedule_switch.async_turn_off()
+    patched_thm.set_schedule_enabled.assert_awaited_once_with(False)
+
+
+async def test_schedule_turn_on_swallows_error(schedule_switch, patched_thm, caplog):
+    patched_thm.set_schedule_enabled.side_effect = RuntimeError("nope")
+    await schedule_switch.async_turn_on()
+    assert "Failed to enable THM schedule" in caplog.text
+
+
+async def test_schedule_optimistic_state(schedule_switch, patched_thm, mock_coordinator):
+    schedule_switch.coordinator.async_request_refresh = AsyncMock()
+    assert schedule_switch.is_on is False
+
+    await schedule_switch.async_turn_on()
+    # Stale coordinator still says OFF; optimistic must report ON.
+    assert schedule_switch.is_on is True
+
+    # Coordinator catches up.
+    _coordinator_with_thm(mock_coordinator, schedule_enabled=True)
+    assert schedule_switch.is_on is True
+    assert schedule_switch._pending is None
+
+
+# ---------------------------------------------------------------------------
+# Humidity mode select
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def humidity_mode_select(mock_coordinator):
+    device = _coordinator_with_thm(mock_coordinator)
+    sel = ThmHumidityModeSelect(
+        mock_coordinator, THM_DEVICE_ID, device, MOCK_BUILDING_ID
+    )
+    sel.async_write_ha_state = MagicMock()
+    return sel
+
+
+def test_humidity_mode_options(humidity_mode_select):
+    assert humidity_mode_select.options == ["off", "on", "auto"]
+
+
+@pytest.mark.parametrize("mode", ["off", "on", "auto"])
+def test_humidity_mode_current_option(mock_coordinator, mode):
+    device = _coordinator_with_thm(mock_coordinator, humidity_mode=mode)
+    sel = ThmHumidityModeSelect(
+        mock_coordinator, THM_DEVICE_ID, device, MOCK_BUILDING_ID
+    )
+    assert sel.current_option == mode
+
+
+@pytest.mark.parametrize("mode", ["off", "on", "auto"])
+async def test_humidity_mode_select_calls_setter(
+    humidity_mode_select, patched_thm, mode
+):
+    humidity_mode_select.coordinator.async_request_refresh = AsyncMock()
+    await humidity_mode_select.async_select_option(mode)
+    patched_thm.set_humidity_mode.assert_awaited_once_with(mode)
+
+
+async def test_humidity_mode_select_swallows_error(
+    humidity_mode_select, patched_thm, caplog
+):
+    patched_thm.set_humidity_mode.side_effect = RuntimeError("nope")
+    await humidity_mode_select.async_select_option("auto")
+    assert "Failed to set THM humidity mode" in caplog.text
+
+
+async def test_humidity_mode_optimistic(
+    humidity_mode_select, patched_thm, mock_coordinator
+):
+    humidity_mode_select.coordinator.async_request_refresh = AsyncMock()
+    assert humidity_mode_select.current_option == "off"
+
+    await humidity_mode_select.async_select_option("auto")
+    assert humidity_mode_select.current_option == "auto"
+    assert humidity_mode_select._pending == "auto"
+
+    _coordinator_with_thm(mock_coordinator, humidity_mode="auto")
+    assert humidity_mode_select.current_option == "auto"
+    assert humidity_mode_select._pending is None
+
+
+# ---------------------------------------------------------------------------
+# Humidity target number
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def humidity_target_number(mock_coordinator):
+    device = _coordinator_with_thm(mock_coordinator)
+    num = ThmHumidityTargetNumber(
+        mock_coordinator, THM_DEVICE_ID, device, MOCK_BUILDING_ID
+    )
+    num.async_write_ha_state = MagicMock()
+    return num
+
+
+def test_humidity_target_native_value(humidity_target_number):
+    assert humidity_target_number.native_value == 40.0
+
+
+def test_humidity_target_range_metadata(humidity_target_number):
+    assert humidity_target_number._attr_native_min_value == 0
+    assert humidity_target_number._attr_native_max_value == 100
+    assert humidity_target_number._attr_native_step == 1
+    assert humidity_target_number._attr_native_unit_of_measurement == "%"
+
+
+async def test_humidity_target_set_calls_setter(humidity_target_number, patched_thm):
+    humidity_target_number.coordinator.async_request_refresh = AsyncMock()
+    await humidity_target_number.async_set_native_value(45)
+    patched_thm.set_humidity_target.assert_awaited_once_with(45)
+    humidity_target_number.coordinator.async_request_refresh.assert_awaited()
+
+
+async def test_humidity_target_rounds_float_to_int(
+    humidity_target_number, patched_thm
+):
+    humidity_target_number.coordinator.async_request_refresh = AsyncMock()
+    await humidity_target_number.async_set_native_value(42.7)
+    patched_thm.set_humidity_target.assert_awaited_once_with(43)
+
+
+async def test_humidity_target_swallows_error(
+    humidity_target_number, patched_thm, caplog
+):
+    patched_thm.set_humidity_target.side_effect = RuntimeError("nope")
+    await humidity_target_number.async_set_native_value(50)
+    assert "Failed to set THM humidity target" in caplog.text
+
+
+async def test_humidity_target_optimistic(
+    humidity_target_number, patched_thm, mock_coordinator
+):
+    humidity_target_number.coordinator.async_request_refresh = AsyncMock()
+    assert humidity_target_number.native_value == 40.0
+
+    await humidity_target_number.async_set_native_value(45)
+    assert humidity_target_number.native_value == 45.0
+    assert humidity_target_number._pending == 45
+
+    _coordinator_with_thm(mock_coordinator, humidity_target=45)
+    assert humidity_target_number.native_value == 45.0
+    assert humidity_target_number._pending is None
+
+
+# ---------------------------------------------------------------------------
+# Coordinator extraction (raw device dict → parameters)
+# ---------------------------------------------------------------------------
+
+async def test_coordinator_extracts_pgmble_usehum_hmt():
+    """``_extract_thm_parameters`` reads pgmble/useHum/hmT directly off the device."""
+    from custom_components.hbx_controls.coordinator import _extract_thm_parameters
+
+    device_helper = MagicMock()
+    # All getters return None / raise so only the raw-field path matters.
+    device_helper.get_device_info = AsyncMock(side_effect=Exception("unused"))
+    device_helper.get_setpoint = AsyncMock(side_effect=Exception("unused"))
+    device_helper.get_room_temperature = AsyncMock(side_effect=Exception("unused"))
+    device_helper.get_floor_temperature = AsyncMock(side_effect=Exception("unused"))
+    device_helper.get_humidity = AsyncMock(side_effect=Exception("unused"))
+    device_helper.get_changeover_mode = AsyncMock(side_effect=Exception("unused"))
+    device_helper.get_thm_mode = AsyncMock(side_effect=Exception("unused"))
+    device_helper.get_fan_mode = AsyncMock(side_effect=Exception("unused"))
+    device_helper.get_is_heating = AsyncMock(side_effect=Exception("unused"))
+    device_helper.get_is_cooling = AsyncMock(side_effect=Exception("unused"))
+    device_helper.get_away_mode = AsyncMock(side_effect=Exception("unused"))
+
+    device = {"pgmble": 1, "useHum": 2, "hmT": 45}
+    params = await _extract_thm_parameters(device_helper, device)
+
+    assert params["schedule_enabled"] is True
+    assert params["humidity_mode"] == "auto"
+    assert params["humidity_target"] == 45
+
+
+async def test_coordinator_omits_thm_fields_when_absent():
+    from custom_components.hbx_controls.coordinator import _extract_thm_parameters
+
+    device_helper = MagicMock()
+    for attr in (
+        "get_device_info", "get_setpoint", "get_room_temperature",
+        "get_floor_temperature", "get_humidity", "get_changeover_mode",
+        "get_thm_mode", "get_fan_mode", "get_is_heating", "get_is_cooling",
+        "get_away_mode",
+    ):
+        setattr(device_helper, attr, AsyncMock(side_effect=Exception("unused")))
+
+    params = await _extract_thm_parameters(device_helper, {})
+    assert "schedule_enabled" not in params
+    assert "humidity_mode" not in params
+    assert "humidity_target" not in params
+
+
+@pytest.mark.parametrize(
+    "use_hum,expected",
+    [(0, "off"), (1, "on"), (2, "auto")],
+)
+async def test_coordinator_humidity_mode_mapping(use_hum, expected):
+    from custom_components.hbx_controls.coordinator import _extract_thm_parameters
+
+    device_helper = MagicMock()
+    for attr in (
+        "get_device_info", "get_setpoint", "get_room_temperature",
+        "get_floor_temperature", "get_humidity", "get_changeover_mode",
+        "get_thm_mode", "get_fan_mode", "get_is_heating", "get_is_cooling",
+        "get_away_mode",
+    ):
+        setattr(device_helper, attr, AsyncMock(side_effect=Exception("unused")))
+
+    params = await _extract_thm_parameters(device_helper, {"useHum": use_hum})
+    assert params["humidity_mode"] == expected


### PR DESCRIPTION
## Summary

Adds three new write entities for THM thermostats, gated on `pysensorlinx==0.5.0` (released earlier today, which added the underlying setters):

| Entity | HBX field | Values |
|---|---|---|
| `switch.<thm>_schedule` | `pgmble` | 0 / 1 |
| `select.<thm>_humidity_mode` | `useHum` | 0=off / 1=on / 2=auto |
| `number.<thm>_humidity_target` | `hmT` | 0-100 % |

Field mappings were confirmed via paired before/after device dumps from a real THM-0600 (issue #12, attached 2026-04-28).

## Implementation notes

- **Optimistic state**: each entity follows the `ZonAppButtonSwitch` template — it stamps a `_pending` value on write and returns that until the coordinator catches up, so the UI doesn't flicker during the 1-2s refresh delay.
- **Coordinator extraction**: pysensorlinx 0.5.0 has setters but no getters for these fields yet. Easiest path is to read `pgmble`/`useHum`/`hmT` directly off the raw device dict — they sit at the top level of the device JSON.
- **Humidity mode** is a 3-state enum (off/on/auto) — initial speculation that it was a single boolean was wrong.

## Tests

- 33 new tests in `tests/test_thm_schedule_humidity.py` covering entity wiring, optimistic state, error handling, and raw-field-to-parameter mapping.
- Full suite: **349 → 382 passed**.

## Validation plan

Beta tester (issue #12) can validate by:
1. Toggling `switch.<thm>_schedule` and confirming the HBX mobile app reflects program enable/disable.
2. Cycling `select.<thm>_humidity_mode` through off/on/auto.
3. Adjusting `number.<thm>_humidity_target` from 40 → 45 → 40 and confirming the app picks up the new value.
