### PR TITLE
fix: 2.5.0b5 - use relType length to size ZON zone entities

### DIFF
--- a/custom_components/hbx_controls/binary_sensor.py
+++ b/custom_components/hbx_controls/binary_sensor.py
@@ -106,14 +106,26 @@ async def async_setup_entry(
             if dtype == DEVICE_TYPE_ZON:
                 relays = device_parameters.get("relays") or []
                 relay_types = device_parameters.get("relay_types") or []
-                # Best-effort: only create entities for slots that look
-                # configured. Relay slots with relay_type == 0 are presumed
-                # disabled / unwired; if relay_types is missing entirely,
-                # fall back to all 16 slots so we don't silently skip
-                # everything on devices that don't report the array.
-                for idx in range(len(relays)):
-                    rtype = relay_types[idx] if idx < len(relay_types) else None
-                    if rtype is not None and rtype == 0:
+                # ``relay_types`` (HBX ``relType``) is the authoritative
+                # zone-count signal: its length tells us how many zone
+                # slots this physical ZON exposes (4 on a ZON-0224, 8 on
+                # ZON-08xx, etc.) and a value of 0 marks a slot as unwired.
+                # ``relays`` (HBX ``relays``) is always 16 entries on the
+                # wire — a superset that includes things beyond zones —
+                # so iterating over it produced phantom "Zone 5..16"
+                # sensors on a 4-zone box (issue #12).
+                #
+                # Strategy: trust ``relay_types`` length when present and
+                # skip slots where ``relay_types[i] == 0``. Only fall back
+                # to ``len(relays)`` when ``relay_types`` is missing
+                # entirely so devices that don't report it still get
+                # something rather than nothing.
+                if relay_types:
+                    zone_count = len(relay_types)
+                else:
+                    zone_count = len(relays)
+                for idx in range(zone_count):
+                    if relay_types and relay_types[idx] == 0:
                         continue
                     entities.append(
                         ZonRelayDemandBinarySensor(

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
   "requirements": ["pysensorlinx==0.5.0"],
-  "version": "2.5.0b4"
+  "version": "2.5.0b5"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b4"
+version = "2.5.0b5"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_zon_relay_sensors.py
+++ b/tests/test_zon_relay_sensors.py
@@ -57,6 +57,31 @@ async def test_setup_creates_one_entity_per_configured_relay(
     assert sorted(e._index for e in relay_entities) == [0, 1, 2]
 
 
+async def test_setup_uses_relay_types_length_when_relays_is_superset(
+    hass, mock_coordinator, mock_config_entry
+):
+    """
+    Real-hardware regression (issue #12): the HBX cloud API returns a
+    16-element ``relays`` array on every ZON regardless of physical zone
+    count. ``relType`` (HBX) -> ``relay_types`` (our coordinator) is the
+    authoritative source of zone count and per-slot wiring state. A
+    4-zone ZON-0224 with 3 zones wired must yield 3 entities, not 15.
+    """
+    _coordinator_with_zon(
+        mock_coordinator,
+        relays=[False] * 16,
+        relay_types=[1, 1, 1, 0],  # eelton's AZON-0224
+    )
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+
+    relay_entities = [e for e in entities if isinstance(e, ZonRelayDemandBinarySensor)]
+    assert len(relay_entities) == 3
+    assert sorted(e._index for e in relay_entities) == [0, 1, 2]
+
+
 async def test_setup_falls_back_to_all_slots_when_relay_types_missing(
     hass, mock_coordinator, mock_config_entry
 ):
@@ -71,11 +96,11 @@ async def test_setup_falls_back_to_all_slots_when_relay_types_missing(
     assert len(relay_entities) == 16
 
 
-async def test_setup_skips_when_relays_array_missing(
+async def test_setup_skips_when_relays_and_relay_types_both_missing(
     hass, mock_coordinator, mock_config_entry
 ):
-    """Devices without a relays array yield no relay sensors."""
-    _coordinator_with_zon(mock_coordinator, relays=[])
+    """Devices without any relay info at all yield no relay sensors."""
+    _coordinator_with_zon(mock_coordinator, relays=[], relay_types=[])
     hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
 
     entities = []


### PR DESCRIPTION
## Summary

Fixes the 4-zones-on-hardware-shows-as-15-zones regression eelton reported in #12 after running 2.5.0b3+.

## Root cause

The HBX cloud API returns a fixed **16-element `relays` array on every ZON** regardless of physical zone count. The setup loop in `binary_sensor.async_setup_entry` was iterating `len(relays)` and only filtering when `relay_types[i]` was explicitly `0` — so any slot beyond the end of `relay_types` (which IS the per-device, real length) became a phantom "Zone N" entity.

## Fix

Use **`relay_types`** (HBX `relType`) as the authoritative zone-count source. The new logic:

1. If `relay_types` is present (truthy), iterate over `range(len(relay_types))` and skip slots where `relay_types[i] == 0` (unwired).
2. Only fall back to `len(relays)` when `relay_types` is missing entirely.

## Confirmed against the dump in #12

```
relType: [1, 1, 1, 0]                                      (3 wired, 1 unwired)
relays:  [false × 16]
thmInfo: ["ATHM-4304", "ATHM-2625", "ATHM-2619", null]
```

After fix: 3 entities with indices [0, 1, 2]. ✅

## Tests

- New `test_setup_uses_relay_types_length_when_relays_is_superset` encodes the exact AZON-0224 scenario from the dump.
- Updated `test_setup_skips_when_relays_and_relay_types_both_missing` to reflect the slightly stronger guard (need both arrays empty to skip — having `relay_types` alone is enough to create entities, since zones are still real even if live state hasn't arrived yet).
- Full suite: **382 → 383 passed**.

## Out of scope

Eelton also flagged that `select.<thm>_hvac_mode_priority` (heat/cool/auto, no off) doesn't write — that's a separate, pre-existing bug to investigate after this fix lands.
