### PR TITLE
fix: 2.5.0b6 - hide HVAC mode priority select on THM/ZON devices

### DIFF
--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
   "requirements": ["pysensorlinx==0.5.0"],
-  "version": "2.5.0b5"
+  "version": "2.5.0b6"
 }

--- a/custom_components/hbx_controls/select.py
+++ b/custom_components/hbx_controls/select.py
@@ -38,8 +38,13 @@ async def async_setup_entry(
             device_parameters = device.get("parameters", {})
             building_id = device.get("building_id")
             
-            # HVAC Mode Priority
-            if "hvac_mode" in device_parameters:
+            # HVAC Mode Priority — ECO/HHB-only concept (writes the ``prior``
+            # field).  THM/ZON parameter dicts also expose ``hvac_mode`` but
+            # mean a different thing (the THM's own changeover mode), and
+            # routing those through ``set_hvac_mode_priority`` writes a field
+            # the THM ignores.  Gate strictly to non-THM/non-ZON devices.
+            device_type = (device_parameters.get("device_type") or "").upper()
+            if "hvac_mode" in device_parameters and device_type not in ("THM", "ZON"):
                 entities.append(
                     HvacModePrioritySelect(
                         coordinator,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b5"
+version = "2.5.0b6"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -82,6 +82,43 @@ async def test_setup_no_data(
     assert len(entities) == 0
 
 
+async def test_setup_skips_thm_with_hvac_mode(
+    hass: HomeAssistant, mock_coordinator, mock_config_entry
+):
+    """THM devices expose ``hvac_mode`` (their own changeover mode) but the
+    HVAC mode priority select is an ECO concept that writes the ``prior``
+    field — which a THM ignores.  Regression test for the eelton-reported bug
+    where the priority select appeared on his THM, snapped back to "heat" on
+    every write, and lacked an "off" option.
+    """
+    params = {"hvac_mode": "heat", "device_type": "THM"}
+    device = make_device(device_type="THM", parameters=params)
+    mock_coordinator.data = make_coordinator_data(devices={MOCK_DEVICE_ID: device})
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, lambda e: entities.extend(e))
+
+    assert not any(isinstance(e, HvacModePrioritySelect) for e in entities)
+
+
+async def test_setup_skips_zon_with_hvac_mode(
+    hass: HomeAssistant, mock_coordinator, mock_config_entry
+):
+    """ZON devices should never get the HVAC mode priority select either."""
+    params = {"hvac_mode": "heat", "device_type": "ZON"}
+    device = make_device(device_type="ZON", parameters=params)
+    mock_coordinator.data = make_coordinator_data(devices={MOCK_DEVICE_ID: device})
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, lambda e: entities.extend(e))
+
+    assert not any(isinstance(e, HvacModePrioritySelect) for e in entities)
+
+
 # ---------------------------------------------------------------------------
 # Options
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the HVAC mode priority select bug eelton reported on issue #12 against 2.5.0b4. The select was leaking onto THM (and ZON) devices where it had never belonged.

## Root cause

`parameters["hvac_mode"]` is populated by two different extractors that mean unrelated things:

| Extractor | Source | Values | Concept |
|---|---|---|---|
| `_extract_eco_parameters` | `get_hvac_mode_priority()` reads `prior` | heat/cool/auto | ECO system priority |
| `_extract_thm_parameters` | `get_hvac_mode()` reads `changeover[].activated.key` | off/heat/cool/auto | THM changeover mode |

`select.py` blindly created `HvacModePrioritySelect` whenever the key was present. On a THM, the select displayed the THM's actual mode but its writer called `set_hvac_mode_priority()` which patches `prior` — a field the THM does not honour. So:

- Selection snapped back to the previous value on every coordinator refresh
- HBX-app changes were never reflected (different field on the read side)
- "off" was missing from `_attr_options` (priority has no off)

## Fix

Gate `HvacModePrioritySelect` creation to non-THM/non-ZON devices using `parameters["device_type"]`. ECO behaviour unchanged. Proper THM mode control will arrive with the climate entity.

## Tests

- `test_setup_skips_thm_with_hvac_mode` — regression test for eelton's case
- `test_setup_skips_zon_with_hvac_mode` — same check for ZONs
- 385 total (was 383)

## Validation

eelton should see the broken priority selector vanish from his THM device page. We'll prompt him for confirmation in the issue thread.
