### PR TITLE
fix: 2.5.0b7 - whitelist ECO for HVAC mode priority select

### DIFF
--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
   "requirements": ["pysensorlinx==0.5.0"],
-  "version": "2.5.0b6"
+  "version": "2.5.0b7"
 }

--- a/custom_components/hbx_controls/select.py
+++ b/custom_components/hbx_controls/select.py
@@ -42,9 +42,13 @@ async def async_setup_entry(
             # field).  THM/ZON parameter dicts also expose ``hvac_mode`` but
             # mean a different thing (the THM's own changeover mode), and
             # routing those through ``set_hvac_mode_priority`` writes a field
-            # the THM ignores.  Gate strictly to non-THM/non-ZON devices.
+            # the THM ignores.  Whitelist ECO explicitly: the coordinator's
+            # ECO extractor is also the fallback for unknown device types, so
+            # a blacklist would re-leak this entity onto any new HBX device
+            # class that happens to expose ``hvac_mode`` for a different
+            # purpose.
             device_type = (device_parameters.get("device_type") or "").upper()
-            if "hvac_mode" in device_parameters and device_type not in ("THM", "ZON"):
+            if "hvac_mode" in device_parameters and device_type == "ECO":
                 entities.append(
                     HvacModePrioritySelect(
                         coordinator,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b6"
+version = "2.5.0b7"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -119,6 +119,29 @@ async def test_setup_skips_zon_with_hvac_mode(
     assert not any(isinstance(e, HvacModePrioritySelect) for e in entities)
 
 
+async def test_setup_skips_unknown_device_type_with_hvac_mode(
+    hass: HomeAssistant, mock_coordinator, mock_config_entry
+):
+    """Unknown device types must not get the priority select.
+
+    The coordinator's ECO extractor doubles as the fallback for unknown
+    types, so a future HBX device class with an unrelated ``hvac_mode``
+    field could regress us if we blacklist instead of whitelist.  The gate
+    is positive (``device_type == "ECO"``); confirm an unknown type with
+    an ``hvac_mode`` value does NOT spawn the entity.
+    """
+    params = {"hvac_mode": "heat", "device_type": "FUTURE"}
+    device = make_device(device_type="FUTURE", parameters=params)
+    mock_coordinator.data = make_coordinator_data(devices={MOCK_DEVICE_ID: device})
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, lambda e: entities.extend(e))
+
+    assert not any(isinstance(e, HvacModePrioritySelect) for e in entities)
+
+
 # ---------------------------------------------------------------------------
 # Options
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Tightens the HVAC mode priority select gate from a blacklist (`device_type not in {THM, ZON}`) to a whitelist (`device_type == "ECO"`). Surfaced by a rubber-duck audit of the 2.5.0b6 fix.

## Why

The coordinator's `_extract_eco_parameters` is also the fallback extractor for **unknown** device types (`coordinator.py:361-363`). With a blacklist, a future HBX device class that exposes `hvac_mode` for some unrelated purpose would silently re-leak `HvacModePrioritySelect` onto it — exactly the same class of bug 2.5.0b6 fixed for THM/ZON. The positive whitelist closes that hole.

## Tests

- `test_setup_skips_unknown_device_type_with_hvac_mode` — regression test for a `device_type="FUTURE"` device with `hvac_mode` set; asserts no priority select is created.
- 386 total (was 385).

## Follow-up

Separate issue filed for the schema-level rename (`hvac_mode_priority` for ECO, `changeover_mode` for THM) which is the proper structural fix to remove the overloaded key entirely. That touches `climate.py` plus the `_extract_*` functions and is too big for a beta hotfix.
