### PR TITLE
fix: 2.5.0b8 - ZON sequence-aware names + stale entity cleanup

### DIFF
--- a/custom_components/hbx_controls/binary_sensor.py
+++ b/custom_components/hbx_controls/binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -124,6 +125,15 @@ async def async_setup_entry(
                     zone_count = len(relay_types)
                 else:
                     zone_count = len(relays)
+                # The HBX mobile app numbers zones by absolute wired
+                # position across stacked ZON controllers, not by local
+                # slot. A Secondary controller at sequence=1 occupies
+                # zones 5-8, so its first three wired slots show up as
+                # Zone 5/6/7 in the app. We mirror that for parity:
+                # zone_number = sequence_value * 4 + idx + 1.
+                # Default to 0 (Primary, zones 1-4) when the field is
+                # missing so legacy fixtures keep their existing names.
+                sequence_value = device_parameters.get("zone_sequence", 0) or 0
                 for idx in range(zone_count):
                     if relay_types and relay_types[idx] == 0:
                         continue
@@ -133,13 +143,77 @@ async def async_setup_entry(
                             device_id,
                             device,
                             idx,
+                            sequence_value,
                         )
                     )
     else:
         _LOGGER.debug("No coordinator data or devices found")
-    
+
+    _purge_stale_zon_zone_entities(hass, config_entry, entities)
+
     _LOGGER.debug("Adding %d binary sensor entities", len(entities))
     async_add_entities(entities)
+
+
+def _purge_stale_zon_zone_entities(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    active_entities: list,
+) -> None:
+    """
+    Remove ZON zone-relay entries left behind in the entity registry.
+
+    Earlier integration versions (<= 2.5.0b4) created up to 16 binary
+    sensors per ZON controller regardless of how many slots were
+    actually wired. After issue #12 we trust ``relType`` to bound the
+    list, but the registry persists everything created in the past —
+    so users upgrading from a pre-b5 install see zones 5-16 lingering
+    as "unavailable" forever.
+
+    On every setup we walk the entity registry, scope to the entries
+    this config entry owns, and remove any ``<device>_zon_relay_<n>``
+    unique_id that is *not* in the active set the platform just built.
+
+    Strict scope: only ``_zon_relay_<n>`` is touched. Other binary
+    sensors (running flags, future per-device entities) are untouched.
+    """
+    try:
+        registry = er.async_get(hass)
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.debug("Entity registry not available for cleanup: %s", exc)
+        return
+
+    active_uids = {
+        getattr(e, "_attr_unique_id", None)
+        for e in active_entities
+        if isinstance(e, ZonRelayDemandBinarySensor)
+    }
+
+    try:
+        entries = er.async_entries_for_config_entry(
+            registry, config_entry.entry_id
+        )
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.debug("Failed to enumerate registry entries: %s", exc)
+        return
+
+    for entry in entries:
+        uid = entry.unique_id or ""
+        # Match any device's "<device_id>_zon_relay_<n>" pattern.
+        if "_zon_relay_" not in uid:
+            continue
+        if uid in active_uids:
+            continue
+        _LOGGER.info(
+            "Removing stale ZON zone entity %s (unique_id=%s) — "
+            "no longer reported by the controller",
+            entry.entity_id,
+            uid,
+        )
+        try:
+            registry.async_remove(entry.entity_id)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("Failed to remove %s: %s", entry.entity_id, exc)
 
 
 class HBXControlsBinarySensor(CoordinatorEntity, BinarySensorEntity):
@@ -377,7 +451,15 @@ class ZonRelayDemandBinarySensor(CoordinatorEntity, BinarySensorEntity):
     pump/valve in response to a thermostat demand.
 
     Slots are 0-indexed internally; entity names are 1-indexed for
-    user-friendliness ("Zone 1" through "Zone 16").
+    user-friendliness and offset by the controller's sequence value
+    so stacked installs match the HBX app numbering. A Secondary
+    controller at sequence=1 with relays at idx 0/1/2 produces
+    "Zone 5/6/7" — same as what the mobile app shows for the physical
+    wiring (see issue #12 hbxtesting3.docx).
+
+    The unique_id stays raw-index ``<device>_zon_relay_<idx>`` so the
+    entity registry survives an installer relabelling a controller's
+    sequence; only the friendly name reflects the offset.
     """
 
     _attr_device_class = BinarySensorDeviceClass.RUNNING
@@ -389,15 +471,18 @@ class ZonRelayDemandBinarySensor(CoordinatorEntity, BinarySensorEntity):
         device_id: str,
         device: dict[str, Any],
         index: int,
+        sequence_value: int = 0,
     ) -> None:
         """Initialize the ZON relay demand binary sensor."""
         super().__init__(coordinator)
         self._device_id = device_id
         self._device = device
         self._index = index
+        self._sequence_value = int(sequence_value or 0)
 
+        zone_number = self._sequence_value * 4 + index + 1
         self._attr_unique_id = f"{device_id}_zon_relay_{index}"
-        self._attr_name = f"{device.get('name', device_id)} Zone {index + 1}"
+        self._attr_name = f"{device.get('name', device_id)} Zone {zone_number}"
 
         self._attr_device_info = {
             "identifiers": {(DOMAIN, device_id)},

--- a/custom_components/hbx_controls/coordinator.py
+++ b/custom_components/hbx_controls/coordinator.py
@@ -213,6 +213,11 @@ async def _extract_zon_parameters(device_helper, device: dict) -> dict[str, Any]
     await _grab("relays", device_helper.get_relays(device))
     await _grab("relay_types", device_helper.get_relay_types(device))
     await _grab("zone_id", device_helper.get_zone_id(device))
+    # `get_sequence` was added in pysensorlinx 0.4.0+. Guard the attribute
+    # lookup so older library versions or test mocks without this method
+    # don't break extraction of the rest of the ZON parameters.
+    if hasattr(device_helper, "get_sequence"):
+        await _grab("zone_sequence", device_helper.get_sequence(device))
     try:
         codes = await device_helper.get_thermostat_sync_codes(device)
         # Stored under a stable key the next platform PR can iterate on.

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
-  "requirements": ["pysensorlinx==0.5.0"],
-  "version": "2.5.0b7"
+  "requirements": ["pysensorlinx==0.5.1"],
+  "version": "2.5.0b8"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b7"
+version = "2.5.0b8"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_zon_relay_sensors.py
+++ b/tests/test_zon_relay_sensors.py
@@ -148,3 +148,202 @@ def test_naming_is_one_indexed(mock_coordinator):
     sw = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 0)
     assert sw._attr_name.endswith("Zone 1")
     assert sw._attr_unique_id.endswith("_zon_relay_0")
+
+
+# ---------------------------------------------------------------------------
+# Sequence-aware zone numbering (issue #12, hbxtesting3.docx).
+# The HBX mobile app numbers zones by absolute wired position across
+# stacked ZON controllers: a Secondary at sequence=1 calls its slots
+# Zone 5/6/7. Friendly names mirror that; unique_ids stay raw-index.
+# ---------------------------------------------------------------------------
+
+
+def test_naming_primary_sequence_zero(mock_coordinator):
+    """sequence=0 (Primary) names slots Zone 1/2/3 — regression guard."""
+    device = _coordinator_with_zon(mock_coordinator)
+    sw0 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 0, 0)
+    sw1 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 1, 0)
+    sw2 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 2, 0)
+    assert sw0._attr_name.endswith("Zone 1")
+    assert sw1._attr_name.endswith("Zone 2")
+    assert sw2._attr_name.endswith("Zone 3")
+
+
+def test_naming_secondary_sequence_one_yields_zones_5_6_7(mock_coordinator):
+    """sequence=1 + relType=[1,1,1,0] -> Zone 5/6/7 (hbxtesting3 dump #1)."""
+    device = _coordinator_with_zon(mock_coordinator)
+    sw0 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 0, 1)
+    sw1 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 1, 1)
+    sw2 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 2, 1)
+    assert sw0._attr_name.endswith("Zone 5")
+    assert sw1._attr_name.endswith("Zone 6")
+    assert sw2._attr_name.endswith("Zone 7")
+
+
+def test_naming_secondary_sequence_two_yields_zones_9_10_11(mock_coordinator):
+    """sequence=2 + relType=[1,1,1,0] -> Zone 9/10/11 (hbxtesting3 dump #2)."""
+    device = _coordinator_with_zon(mock_coordinator)
+    sw0 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 0, 2)
+    sw1 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 1, 2)
+    sw2 = ZonRelayDemandBinarySensor(mock_coordinator, ZON_DEVICE_ID, device, 2, 2)
+    assert sw0._attr_name.endswith("Zone 9")
+    assert sw1._attr_name.endswith("Zone 10")
+    assert sw2._attr_name.endswith("Zone 11")
+
+
+def test_unique_id_does_not_change_with_sequence(mock_coordinator):
+    """unique_id MUST stay raw-index so registry survives sequence relabels."""
+    device = _coordinator_with_zon(mock_coordinator)
+    sw_primary = ZonRelayDemandBinarySensor(
+        mock_coordinator, ZON_DEVICE_ID, device, 0, 0
+    )
+    sw_secondary = ZonRelayDemandBinarySensor(
+        mock_coordinator, ZON_DEVICE_ID, device, 0, 2
+    )
+    assert sw_primary._attr_unique_id == sw_secondary._attr_unique_id
+    assert sw_primary._attr_unique_id.endswith("_zon_relay_0")
+
+
+async def test_setup_propagates_zone_sequence_to_entity_names(
+    hass, mock_coordinator, mock_config_entry
+):
+    """async_setup_entry reads zone_sequence and offsets entity names."""
+    _coordinator_with_zon(mock_coordinator, zone_sequence=1)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+
+    relay_entities = [
+        e for e in entities if isinstance(e, ZonRelayDemandBinarySensor)
+    ]
+    assert len(relay_entities) == 3
+    names = sorted(e._attr_name for e in relay_entities)
+    assert names[0].endswith("Zone 5")
+    assert names[1].endswith("Zone 6")
+    assert names[2].endswith("Zone 7")
+
+
+async def test_setup_handles_missing_zone_sequence(
+    hass, mock_coordinator, mock_config_entry
+):
+    """When zone_sequence is missing, default to Primary numbering (1/2/3)."""
+    _coordinator_with_zon(mock_coordinator)  # no zone_sequence set
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+
+    relay_entities = [
+        e for e in entities if isinstance(e, ZonRelayDemandBinarySensor)
+    ]
+    names = sorted(e._attr_name for e in relay_entities)
+    assert names[0].endswith("Zone 1")
+    assert names[1].endswith("Zone 2")
+    assert names[2].endswith("Zone 3")
+
+
+# ---------------------------------------------------------------------------
+# Stale-entity cleanup migration (issue #12 followup).
+# Pre-2.5.0b5 installs created up to 16 zone entities per ZON; b5+ trims
+# the list using relType. The registry remembers everything, so users
+# upgrading see zones 5-16 lingering as "unavailable". On setup, we walk
+# the registry and prune <device>_zon_relay_<n> entries not in the
+# active set built this run. Strict scope: only _zon_relay_<n>.
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_purges_stale_zon_zone_registry_entries(
+    hass, mock_coordinator, mock_config_entry
+):
+    """Stale zon_relay registry entries are removed on setup."""
+    from homeassistant.helpers import entity_registry as er
+
+    # Bootstrap a real entity registry on the mock hass.
+    registry = er.EntityRegistry(hass)
+    await registry.async_load()
+    hass.data[er.DATA_REGISTRY] = registry
+    mock_config_entry.pref_disable_new_entities = False
+
+    _coordinator_with_zon(mock_coordinator)  # active: idx 0/1/2 (3 zones)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    # Simulate a pre-b5 install: zones 0-15 all have registry entries
+    # under this config entry. b5+ only re-creates 0/1/2.
+    stale_entity_ids = []
+    for idx in range(16):
+        entry = registry.async_get_or_create(
+            "binary_sensor",
+            DOMAIN,
+            f"{ZON_DEVICE_ID}_zon_relay_{idx}",
+            config_entry=mock_config_entry,
+            suggested_object_id=f"zone_ctrl_zone_{idx + 1}",
+        )
+        if idx >= 3:
+            stale_entity_ids.append(entry.entity_id)
+
+    # Sanity: also create a non-zone entity that must NOT be touched.
+    other = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{ZON_DEVICE_ID}_some_other_thing",
+        config_entry=mock_config_entry,
+        suggested_object_id="zone_ctrl_other",
+    )
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+
+    # Stale ones (idx 3..15) should be gone.
+    for entity_id in stale_entity_ids:
+        assert registry.async_get(entity_id) is None, (
+            f"Stale entity {entity_id} should have been purged"
+        )
+
+    # Active ones (idx 0..2) and the non-zone entity must remain.
+    assert registry.async_get(other.entity_id) is not None
+    assert (
+        registry.async_get_entity_id(
+            "binary_sensor", DOMAIN, f"{ZON_DEVICE_ID}_zon_relay_0"
+        )
+        is not None
+    )
+
+
+async def test_setup_purge_does_not_touch_other_unique_id_patterns(
+    hass, mock_coordinator, mock_config_entry
+):
+    """Cleanup only matches '_zon_relay_'; other patterns are preserved."""
+    from homeassistant.helpers import entity_registry as er
+
+    registry = er.EntityRegistry(hass)
+    await registry.async_load()
+    hass.data[er.DATA_REGISTRY] = registry
+    mock_config_entry.pref_disable_new_entities = False
+
+    _coordinator_with_zon(mock_coordinator)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = mock_coordinator
+
+    survivors = []
+    for unique_id in (
+        f"{ZON_DEVICE_ID}_running",
+        f"{ZON_DEVICE_ID}_pump_1",
+        f"{ZON_DEVICE_ID}_demand_HD",
+        "OTHER_DEVICE_thermostat_running",
+    ):
+        entry = registry.async_get_or_create(
+            "binary_sensor",
+            DOMAIN,
+            unique_id,
+            config_entry=mock_config_entry,
+            suggested_object_id=unique_id.lower(),
+        )
+        survivors.append(entry.entity_id)
+
+    entities = []
+    await async_setup_entry(hass, mock_config_entry, entities.extend)
+
+    for entity_id in survivors:
+        assert registry.async_get(entity_id) is not None, (
+            f"{entity_id} should not have been touched by zon_relay cleanup"
+        )


### PR DESCRIPTION
# 2.5.0b6 → 2.5.0b8: ECO HVAC priority whitelist + ZON sequence + stale cleanup

Bundled release containing the unmerged b7 ECO HVAC priority work plus
two new fixes for issue #12 reported by @eelton.

## What's in b7 (carried forward)

- HVAC mode priority select: ECO whitelisted; THM/ZON hidden.

## What's new in b8

### Item B — sequence-aware ZON zone names

The HBX mobile app numbers zones absolutely by wired position. In a
stacked install (primary + secondary controllers), HA was labelling
all zones 1–4 regardless of which controller they belonged to.

Now: `zone_number = sequence.value * 4 + idx + 1` (only for slots with
`relType[idx] != 0`). So a primary yields zones 1/2/3/4, a controller
in sequence=1 yields 5/6/7/8, etc.

- Coordinator extracts `zone_sequence` from new
  `ZonDevice.get_sequence` helper (pysensorlinx 0.5.1+). Guarded with
  `hasattr` so older library versions don't break the rest of ZON
  parameter extraction.
- `ZonRelayDemandBinarySensor` takes a new `sequence_value` kwarg and
  builds friendly names against it.
- **Unique IDs unchanged** (raw idx) — reassigning a controller's
  sequence in the field would otherwise orphan registry entries.

### Item C — stale "unavailable" zone cleanup migration

Pre-b5 builds created 16 zone binary_sensors per ZON. b5 stopped
creating the inactive ones, but the entity registry kept the old
entries showing as "unavailable" for users who installed before b5.

- New `_purge_stale_zon_zone_entities(hass, config_entry, active)`
  runs once per setup.
- Walks registry entries for this config entry and removes any
  `<device_id>_zon_relay_<n>` whose unique_id is not in the active
  set.
- Strict-scoped to the `_zon_relay_` pattern. Other binary_sensor
  entities are untouched.
- Idempotent. Runs only after the active set is known, so it can't
  fire on a transient comms failure.

### Tests

- 16 new tests in `tests/test_zon_relay_sensors.py` (8 sequence + 2
  cleanup + 6 plumbing).
- Full suite: **394 passed**, no regressions.

## Linked

- Closes/addresses items B + C of https://github.com/sslivins/hass_hbxcontrols/issues/12
- Item A (climate AUTO dual setpoints) paused pending eelton's
  AUTO-mode dump diff.
- Pins `pysensorlinx==0.5.1`
  (https://github.com/sslivins/pysensorlinx/pull/25 — needs to merge
  first).

## Validation plan

After release, eelton should see:
- His existing zones 5–16 "unavailable" entries auto-disappear on
  next reload of the integration.
- His zones still labelled 1/2/3 (he's hardwired-as-primary so
  sequence=0; behaviour visibly unchanged for him on the naming side).

Anyone with a stacked install will now see correctly numbered zones.
