### PR TITLE
feat: 2.5.0b9 - dual heat/cool setpoint AUTO support (HVACMode.HEAT_COOL)

### DIFF
--- a/custom_components/hbx_controls/climate.py
+++ b/custom_components/hbx_controls/climate.py
@@ -8,6 +8,8 @@ from pysensorlinx import DEVICE_TYPE_THM
 from pysensorlinx.sensorlinx import Temperature, ThmDevice
 
 from homeassistant.components.climate import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
     ClimateEntity,
     ClimateEntityFeature,
     HVACAction,
@@ -27,11 +29,14 @@ _LOGGER = logging.getLogger(__name__)
 
 # Map between HA HVACMode values and the strings :py:meth:`ThmDevice.set_hvac_mode`
 # accepts. ``ThmDevice.set_hvac_mode`` writes the matching ``cngOvr`` integer.
+# Note: HA's HEAT_COOL maps to the device's ``auto`` (cngOvr=0). The cloud
+# library still names that enum value ``"auto"``; the public-facing terminology
+# in HA is HEAT_COOL because dual setpoints are advertised in that mode.
 _THM_HVAC_TO_LIB = {
     HVACMode.OFF: "off",
     HVACMode.HEAT: "heat",
     HVACMode.COOL: "cool",
-    HVACMode.AUTO: "auto",
+    HVACMode.HEAT_COOL: "auto",
 }
 
 # Friendly names HA shows for fan modes; mapped to library values when writing.
@@ -300,13 +305,20 @@ class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
     """
     Climate entity for THM-style thermostats (e.g. THM-0600).
 
-    Backed by :class:`pysensorlinx.sensorlinx.ThmDevice` setters introduced
-    in pysensorlinx 0.4.0:
+    Backed by :class:`pysensorlinx.sensorlinx.ThmDevice`.
 
-    * HVAC mode    -> ``cngOvr`` (auto/heat/cool/off)
-    * Fan mode     -> ``fnMode`` (off/on/intermittent)
-    * Setpoint     -> ``target.value`` (°F int)
-    * Away preset  -> ``away`` (0/1)
+    * HVAC mode      -> ``cngOvr`` (auto/heat/cool/off)
+    * Fan mode       -> ``fnMode`` (off/on/intermittent)
+    * Heat setpoint  -> ``rmT`` (°F int)
+    * Cool setpoint  -> ``rmCT`` (°F int)
+    * Away preset    -> ``away`` (0/1)
+
+    Heat-cool dual-setpoint support arrived in pysensorlinx 0.5.2 once
+    we determined that ``rmT`` and ``rmCT`` always reflect the heat
+    target and cool target respectively, even in Auto changeover.
+    The previously-used single-target ``set_target_temperature``
+    inferred the active side from ``target.type``, which is biased to
+    heat in Auto and so cannot drive HEAT_COOL mode correctly.
 
     Reads come from the parameter dict the coordinator extracts via
     :func:`coordinator._extract_thm_parameters`.
@@ -316,7 +328,12 @@ class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
     _attr_min_temp = 35
     _attr_max_temp = 99
     _attr_target_temperature_step = 1
-    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.AUTO]
+    _attr_hvac_modes = [
+        HVACMode.OFF,
+        HVACMode.HEAT,
+        HVACMode.COOL,
+        HVACMode.HEAT_COOL,
+    ]
     _attr_fan_modes = _THM_FAN_MODES
     _attr_preset_modes = _THM_PRESET_MODES
 
@@ -335,8 +352,12 @@ class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
         self._attr_unique_id = f"{device_id}_thm_climate"
         self._attr_name = f"{device.get('name', device_id)} Climate"
 
+        # We advertise BOTH single-setpoint and range features. HA picks
+        # which UI to show based on ``hvac_mode``: HEAT/COOL use the
+        # single setpoint, HEAT_COOL uses target_temperature_low/high.
         self._attr_supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
             | ClimateEntityFeature.FAN_MODE
             | ClimateEntityFeature.PRESET_MODE
             | ClimateEntityFeature.TURN_ON
@@ -396,11 +417,40 @@ class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def target_temperature(self) -> float | None:
-        """Return the active target temperature."""
+        """Return the active single-setpoint target.
+
+        Returned for HEAT (heat setpoint) and COOL (cool setpoint).
+        ``None`` for HEAT_COOL/OFF — those use the low/high pair.
+        """
         params = self._params()
         if not params:
             return None
-        return params.get("target_temperature_room")
+        mode = self.hvac_mode
+        if mode == HVACMode.HEAT:
+            return params.get("heat_setpoint")
+        if mode == HVACMode.COOL:
+            return params.get("cool_setpoint")
+        return None
+
+    @property
+    def target_temperature_low(self) -> float | None:
+        """Heat-side setpoint when in HEAT_COOL mode."""
+        if self.hvac_mode != HVACMode.HEAT_COOL:
+            return None
+        params = self._params()
+        if not params:
+            return None
+        return params.get("heat_setpoint")
+
+    @property
+    def target_temperature_high(self) -> float | None:
+        """Cool-side setpoint when in HEAT_COOL mode."""
+        if self.hvac_mode != HVACMode.HEAT_COOL:
+            return None
+        params = self._params()
+        if not params:
+            return None
+        return params.get("cool_setpoint")
 
     @property
     def hvac_mode(self) -> HVACMode | None:
@@ -416,21 +466,30 @@ class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
         if mode == "cool":
             return HVACMode.COOL
         if mode == "auto":
-            return HVACMode.AUTO
+            return HVACMode.HEAT_COOL
         return None
 
     @property
     def hvac_action(self) -> HVACAction | None:
-        """Return current HVAC action (heating/cooling/idle/off)."""
+        """Return current HVAC action (heating/cooling/idle/off).
+
+        Derived from the ``active_demands`` list (decoded from the
+        ``dmd`` bitfield) — that's the only reliable signal. The
+        cloud's ``isCooling`` flag is broken (always false even with
+        an active cool call). Cooling takes priority over heating in
+        the unlikely event both bits are set; fan-only renders as
+        idle for hydronic systems.
+        """
         params = self._params()
         if not params:
             return None
-        if params.get("is_off"):
+        if self.hvac_mode == HVACMode.OFF or params.get("is_off"):
             return HVACAction.OFF
-        if params.get("is_heating"):
-            return HVACAction.HEATING
-        if params.get("is_cooling"):
+        demands = params.get("active_demands") or []
+        if "cooling" in demands:
             return HVACAction.COOLING
+        if "heating" in demands:
+            return HVACAction.HEATING
         return HVACAction.IDLE
 
     @property
@@ -516,17 +575,37 @@ class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
             )
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Send the new setpoint to the THM device."""
+        """Send setpoint(s) to the THM device.
+
+        Three call shapes:
+
+        * HEAT_COOL: HA passes ``target_temp_low`` (heat) and
+          ``target_temp_high`` (cool). We write both with a single
+          atomic ``set_heat_cool_setpoints`` PATCH.
+        * HEAT: HA passes ``temperature``; we write ``rmT``.
+        * COOL: HA passes ``temperature``; we write ``rmCT``.
+        """
+        low = kwargs.get(ATTR_TARGET_TEMP_LOW)
+        high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         temperature = kwargs.get(ATTR_TEMPERATURE)
-        if temperature is None:
-            return
-        # HA always passes the value in the entity's configured unit
-        # (Fahrenheit for this entity), so no conversion is needed before
-        # constructing the Temperature object.
+
+        helper = self._device_helper()
         try:
-            await self._device_helper().set_target_temperature(
-                Temperature(temperature, "F")
-            )
+            if low is not None and high is not None:
+                await helper.set_heat_cool_setpoints(
+                    Temperature(low, "F"),
+                    Temperature(high, "F"),
+                )
+            elif temperature is not None:
+                mode = self.hvac_mode
+                if mode == HVACMode.COOL:
+                    await helper.set_cool_setpoint(Temperature(temperature, "F"))
+                else:
+                    # Default to heat for HEAT (and any unknown) — matches
+                    # the HBX app's behaviour.
+                    await helper.set_heat_setpoint(Temperature(temperature, "F"))
+            else:
+                return
             await self.coordinator.async_request_refresh()
         except Exception as exc:  # noqa: BLE001
             _LOGGER.error(
@@ -535,8 +614,8 @@ class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
             )
 
     async def async_turn_on(self) -> None:
-        """Turn the thermostat on (resume Auto changeover)."""
-        await self.async_set_hvac_mode(HVACMode.AUTO)
+        """Turn the thermostat on (resume HEAT_COOL changeover)."""
+        await self.async_set_hvac_mode(HVACMode.HEAT_COOL)
 
     async def async_turn_off(self) -> None:
         """Turn the thermostat off (changeover -> Off)."""

--- a/custom_components/hbx_controls/coordinator.py
+++ b/custom_components/hbx_controls/coordinator.py
@@ -161,6 +161,34 @@ async def _extract_thm_parameters(device_helper, device: dict) -> dict[str, Any]
     except Exception as exc:  # noqa: BLE001
         _LOGGER.debug("THM target temp: %s", exc)
 
+    # Dual heat/cool setpoints — pysensorlinx 0.5.2+. Both fields exist
+    # at all times in the device payload regardless of changeover mode;
+    # rmT = heat target, rmCT = cool target.
+    try:
+        heat_setpoint = await device_helper.get_heat_setpoint(device)
+        if heat_setpoint is not None:
+            parameters["heat_setpoint"] = heat_setpoint.value
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.debug("THM heat setpoint: %s", exc)
+
+    try:
+        cool_setpoint = await device_helper.get_cool_setpoint(device)
+        if cool_setpoint is not None:
+            parameters["cool_setpoint"] = cool_setpoint.value
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.debug("THM cool setpoint: %s", exc)
+
+    # Active demand bitfield decoder — pysensorlinx 0.5.2+. Returns a
+    # list (subset of {heating, cooling, fan}) that the climate entity
+    # uses for hvac_action; the cloud's isCooling flag is unreliable.
+    if hasattr(device_helper, "get_active_demands"):
+        try:
+            demands = await device_helper.get_active_demands(device)
+            if demands is not None:
+                parameters["active_demands"] = list(demands)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("THM active demands: %s", exc)
+
     await _grab("humidity", device_helper.get_humidity(device))
     await _grab("hvac_mode", device_helper.get_hvac_mode(device))
     await _grab("fan_mode", device_helper.get_fan_mode(device))

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
-  "requirements": ["pysensorlinx==0.5.1"],
-  "version": "2.5.0b8"
+  "requirements": ["pysensorlinx==0.5.2"],
+  "version": "2.5.0b9"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b8"
+version = "2.5.0b9"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_thm_climate.py
+++ b/tests/test_thm_climate.py
@@ -1,11 +1,16 @@
-"""Tests for the THM climate entity (2.5.0b1)."""
+"""Tests for the THM climate entity (2.5.0b9)."""
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from homeassistant.components.climate import HVACAction, HVACMode
+from homeassistant.components.climate import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    HVACAction,
+    HVACMode,
+)
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
 
@@ -26,14 +31,17 @@ def _thm_params(**overrides):
     params = {
         "device_type": "THM",
         "temperature_room": 71.5,
+        # Legacy single-target — coordinator still emits it but the
+        # entity prefers heat_setpoint/cool_setpoint going forward.
         "target_temperature_room": 70.0,
+        "heat_setpoint": 70.0,
+        "cool_setpoint": 78.0,
         "humidity": 42.0,
         "hvac_mode": "heat",
         "fan_mode": "off",
         "thm_mode": "Air",
         "is_off": False,
-        "is_heating": True,
-        "is_cooling": False,
+        "active_demands": ["heating"],
         "away_mode_activated": False,
     }
     params.update(overrides)
@@ -94,7 +102,36 @@ def test_current_temperature(thm_climate):
 
 
 def test_target_temperature(thm_climate):
+    """In HEAT mode, target_temperature surfaces the heat setpoint."""
     assert thm_climate.target_temperature == 70.0
+
+
+def test_target_temperature_in_cool_mode(mock_coordinator):
+    device = _coordinator_with_thm(mock_coordinator, hvac_mode="cool")
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.target_temperature == 78.0
+
+
+def test_target_temperature_none_in_heat_cool(mock_coordinator):
+    """HEAT_COOL uses target_temperature_low/high, not target_temperature."""
+    device = _coordinator_with_thm(mock_coordinator, hvac_mode="auto")
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.target_temperature is None
+
+
+def test_target_temperature_low_high_in_heat_cool(mock_coordinator):
+    device = _coordinator_with_thm(mock_coordinator, hvac_mode="auto")
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.target_temperature_low == 70.0
+    assert ent.target_temperature_high == 78.0
+
+
+def test_target_temperature_low_high_none_outside_heat_cool(mock_coordinator):
+    """HEAT/COOL/OFF modes report None for the low/high pair."""
+    device = _coordinator_with_thm(mock_coordinator, hvac_mode="heat")
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.target_temperature_low is None
+    assert ent.target_temperature_high is None
 
 
 def test_current_humidity(thm_climate):
@@ -106,25 +143,66 @@ def test_hvac_mode_mapping(mock_coordinator):
         ("off", HVACMode.OFF),
         ("heat", HVACMode.HEAT),
         ("cool", HVACMode.COOL),
-        ("auto", HVACMode.AUTO),
+        ("auto", HVACMode.HEAT_COOL),
     ]:
         device = _coordinator_with_thm(mock_coordinator, hvac_mode=raw)
         ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
         assert ent.hvac_mode == expected
 
 
-def test_hvac_action_off(mock_coordinator):
-    device = _coordinator_with_thm(mock_coordinator, is_off=True, is_heating=False)
+def test_hvac_action_off_via_mode(mock_coordinator):
+    """Mode==off forces HVACAction.OFF even if active_demands is empty."""
+    device = _coordinator_with_thm(
+        mock_coordinator, hvac_mode="off", active_demands=[],
+    )
     ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
     assert ent.hvac_action == HVACAction.OFF
 
 
+def test_hvac_action_off_via_is_off_flag(mock_coordinator):
+    """Legacy is_off flag still respected for back-compat."""
+    device = _coordinator_with_thm(
+        mock_coordinator, is_off=True, active_demands=["heating"],
+    )
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    # is_off should win for safety even though demands say heating.
+    # Our hvac_mode is still "heat" so OFF only fires via the flag.
+    assert ent.hvac_action == HVACAction.OFF
+
+
 def test_hvac_action_heating(thm_climate):
+    """heating bit set in active_demands -> HEATING."""
     assert thm_climate.hvac_action == HVACAction.HEATING
 
 
 def test_hvac_action_cooling(mock_coordinator):
-    device = _coordinator_with_thm(mock_coordinator, is_heating=False, is_cooling=True)
+    device = _coordinator_with_thm(
+        mock_coordinator,
+        hvac_mode="cool",
+        active_demands=["cooling"],
+    )
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.hvac_action == HVACAction.COOLING
+
+
+def test_hvac_action_idle_when_no_demand(mock_coordinator):
+    device = _coordinator_with_thm(mock_coordinator, active_demands=[])
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.hvac_action == HVACAction.IDLE
+
+
+def test_hvac_action_fan_only_is_idle(mock_coordinator):
+    """Hydronic systems treat fan-only as idle (no thermal demand)."""
+    device = _coordinator_with_thm(mock_coordinator, active_demands=["fan"])
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.hvac_action == HVACAction.IDLE
+
+
+def test_hvac_action_cooling_priority(mock_coordinator):
+    """Defensive: if both heating and cooling bits are set, cooling wins."""
+    device = _coordinator_with_thm(
+        mock_coordinator, active_demands=["heating", "cooling"],
+    )
     ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
     assert ent.hvac_action == HVACAction.COOLING
 
@@ -155,7 +233,9 @@ def patched_thm():
         instance.set_hvac_mode = AsyncMock()
         instance.set_fan_mode = AsyncMock()
         instance.set_away_mode = AsyncMock()
-        instance.set_target_temperature = AsyncMock()
+        instance.set_heat_setpoint = AsyncMock()
+        instance.set_cool_setpoint = AsyncMock()
+        instance.set_heat_cool_setpoints = AsyncMock()
         cls.return_value = instance
         yield instance
 
@@ -165,6 +245,12 @@ async def test_async_set_hvac_mode_writes_lib_str(thm_climate, patched_thm):
     await thm_climate.async_set_hvac_mode(HVACMode.COOL)
     patched_thm.set_hvac_mode.assert_awaited_once_with("cool")
     thm_climate.coordinator.async_request_refresh.assert_awaited()
+
+
+async def test_async_set_hvac_mode_heat_cool_maps_to_auto(thm_climate, patched_thm):
+    thm_climate.coordinator.async_request_refresh = AsyncMock()
+    await thm_climate.async_set_hvac_mode(HVACMode.HEAT_COOL)
+    patched_thm.set_hvac_mode.assert_awaited_once_with("auto")
 
 
 async def test_async_set_fan_mode(thm_climate, patched_thm):
@@ -190,16 +276,55 @@ async def test_async_set_preset_none(thm_climate, patched_thm):
     patched_thm.set_away_mode.assert_awaited_once_with(False)
 
 
-async def test_async_set_temperature_uses_fahrenheit(thm_climate, patched_thm):
+async def test_async_set_temperature_in_heat_mode(thm_climate, patched_thm):
+    """Single-setpoint write in HEAT routes to set_heat_setpoint."""
     thm_climate.coordinator.async_request_refresh = AsyncMock()
     await thm_climate.async_set_temperature(**{ATTR_TEMPERATURE: 72})
-    patched_thm.set_target_temperature.assert_awaited_once()
-    temp = patched_thm.set_target_temperature.await_args.args[0]
-    # Temperature object — verify the °F value is preserved
+    patched_thm.set_heat_setpoint.assert_awaited_once()
+    patched_thm.set_cool_setpoint.assert_not_awaited()
+    temp = patched_thm.set_heat_setpoint.await_args.args[0]
     assert temp.to_fahrenheit() == 72
 
 
+async def test_async_set_temperature_in_cool_mode(mock_coordinator, patched_thm):
+    """Single-setpoint write in COOL routes to set_cool_setpoint."""
+    device = _coordinator_with_thm(mock_coordinator, hvac_mode="cool")
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    ent.coordinator.async_request_refresh = AsyncMock()
+    await ent.async_set_temperature(**{ATTR_TEMPERATURE: 78})
+    patched_thm.set_cool_setpoint.assert_awaited_once()
+    patched_thm.set_heat_setpoint.assert_not_awaited()
+    temp = patched_thm.set_cool_setpoint.await_args.args[0]
+    assert temp.to_fahrenheit() == 78
+
+
+async def test_async_set_temperature_heat_cool_low_high(mock_coordinator, patched_thm):
+    """HEAT_COOL writes both setpoints atomically via set_heat_cool_setpoints."""
+    device = _coordinator_with_thm(mock_coordinator, hvac_mode="auto")
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    ent.coordinator.async_request_refresh = AsyncMock()
+    await ent.async_set_temperature(**{
+        ATTR_TARGET_TEMP_LOW: 67,
+        ATTR_TARGET_TEMP_HIGH: 79,
+    })
+    patched_thm.set_heat_cool_setpoints.assert_awaited_once()
+    args = patched_thm.set_heat_cool_setpoints.await_args.args
+    assert args[0].to_fahrenheit() == 67
+    assert args[1].to_fahrenheit() == 79
+    # Single atomic call — must NOT have called the individual setters.
+    patched_thm.set_heat_setpoint.assert_not_awaited()
+    patched_thm.set_cool_setpoint.assert_not_awaited()
+
+
+async def test_async_set_temperature_no_kwargs_is_noop(thm_climate, patched_thm):
+    await thm_climate.async_set_temperature()
+    patched_thm.set_heat_setpoint.assert_not_awaited()
+    patched_thm.set_cool_setpoint.assert_not_awaited()
+    patched_thm.set_heat_cool_setpoints.assert_not_awaited()
+
+
 async def test_async_turn_on_off(thm_climate, patched_thm):
+    """turn_on switches to HEAT_COOL ("auto"); turn_off to OFF."""
     thm_climate.coordinator.async_request_refresh = AsyncMock()
     await thm_climate.async_turn_off()
     await thm_climate.async_turn_on()


### PR DESCRIPTION
## Summary

Replaces the single-target `HVACMode.AUTO` climate mode for THM
thermostats with HA's dual-setpoint `HVACMode.HEAT_COOL`. In
HEAT_COOL the climate card now exposes a heat target (`rmT`) and a
cool target (`rmCT`) independently — matching what the HBX mobile app
shows for thermostats configured in Auto changeover.

Resolves the user-blocking issue eelton flagged on
[issue #12](https://github.com/sslivins/hass_hbxcontrols/issues/12) —
Auto mode previously surfaced only one setpoint in HA.

## What changed

### `climate.py` (`HBXControlsThmClimate`)

| Surface | Before | After |
|---|---|---|
| HVAC mode list | `[OFF, HEAT, COOL, AUTO]` | `[OFF, HEAT, COOL, HEAT_COOL]` |
| Supported features | TARGET_TEMPERATURE | + TARGET_TEMPERATURE_RANGE |
| `target_temperature` | always `target_temperature_room` | HEAT → heat_setpoint, COOL → cool_setpoint, else None |
| `target_temperature_low/high` | absent | HEAT_COOL → heat / cool setpoint |
| `hvac_action` source | `is_heating`/`is_cooling` flags | decoded `active_demands` list |
| `async_set_temperature` | single setter | handles low/high via atomic `set_heat_cool_setpoints`, routes single-setpoint by mode |
| `async_turn_on` | switches to AUTO | switches to HEAT_COOL |

The cloud's `isCooling` flag is broken — it stays `false` even with
an active cool call. The `dmd` bitfield (`0x02`/`0x40`/`0x80` for
heat/cool/fan respectively) is the reliable signal, decoded into a
list by `pysensorlinx 0.5.2`'s new `get_active_demands`.

### `coordinator.py` (`_extract_thm_parameters`)

Adds three new fields:

- `heat_setpoint` — from `ThmDevice.get_heat_setpoint`
- `cool_setpoint` — from `ThmDevice.get_cool_setpoint`
- `active_demands` — from `ThmDevice.get_active_demands` (with
  `hasattr` guard for older library versions)

### Version bumps

- `manifest.json`: 2.5.0b8 → 2.5.0b9; pin `pysensorlinx==0.5.2`
- `pyproject.toml`: 2.5.0b8 → 2.5.0b9

## ⚠️ Behavior change

Any HA automation/script referencing `hvac_mode: auto` on a
hass_hbxcontrols THM thermostat must update to `heat_cool`. The
underlying device behavior (cngOvr=0) is unchanged — only the HA
side label.

## Validation

- New tests for HEAT_COOL flows: target_temperature_low/high reads,
  dual-setpoint atomic write, single-setpoint routing by current
  mode, hvac_action derived from active_demands (with cooling >
  heating priority, fan-only as idle).
- Existing single-setpoint HEAT/COOL flows still pass.
- **Full hass_hbxcontrols suite: 406 passed.**
- pysensorlinx 0.5.2 dependency was just merged & released to PyPI.

## Field semantics confirmed

Five paired before/after dumps from eelton's THM-0600 (Stairway
thermostat) on 2026-04-30 confirmed:

- `rmT` = heat setpoint (always reflects heat target, even in Auto)
- `rmCT` = cool setpoint (always reflects cool target, even in Auto)
- `cngOvr`: 0=Auto, 1=Heat, 2=Cool, 3=Off
- `dmd` is a bitfield with `heat=0x02`, `cool=0x40`, `fan=0x80`
- `target.value` is biased to heat in Auto — must NOT be used as
  truth for either side

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
