### PR TITLE
feat: 2.5.0b10 - route Away-preset writes to awayMode setpoints

### DIFF
--- a/custom_components/hbx_controls/climate.py
+++ b/custom_components/hbx_controls/climate.py
@@ -421,14 +421,23 @@ class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
 
         Returned for HEAT (heat setpoint) and COOL (cool setpoint).
         ``None`` for HEAT_COOL/OFF — those use the low/high pair.
+
+        When the Away preset is active and an away setpoint is published
+        by the device, we return the away value instead so HA's UI
+        reflects what the device is actually targeting.
         """
         params = self._params()
         if not params:
             return None
         mode = self.hvac_mode
+        away = self.preset_mode == _THM_PRESET_AWAY
         if mode == HVACMode.HEAT:
+            if away and params.get("away_heat_setpoint") is not None:
+                return params.get("away_heat_setpoint")
             return params.get("heat_setpoint")
         if mode == HVACMode.COOL:
+            if away and params.get("away_cool_setpoint") is not None:
+                return params.get("away_cool_setpoint")
             return params.get("cool_setpoint")
         return None
 
@@ -440,6 +449,11 @@ class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
         params = self._params()
         if not params:
             return None
+        if (
+            self.preset_mode == _THM_PRESET_AWAY
+            and params.get("away_heat_setpoint") is not None
+        ):
+            return params.get("away_heat_setpoint")
         return params.get("heat_setpoint")
 
     @property
@@ -450,6 +464,11 @@ class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
         params = self._params()
         if not params:
             return None
+        if (
+            self.preset_mode == _THM_PRESET_AWAY
+            and params.get("away_cool_setpoint") is not None
+        ):
+            return params.get("away_cool_setpoint")
         return params.get("cool_setpoint")
 
     @property
@@ -584,26 +603,50 @@ class HBXControlsThmClimate(CoordinatorEntity, ClimateEntity):
           atomic ``set_heat_cool_setpoints`` PATCH.
         * HEAT: HA passes ``temperature``; we write ``rmT``.
         * COOL: HA passes ``temperature``; we write ``rmCT``.
+
+        When the Away preset is active, writes are routed to the
+        ``awayMode.heatTarget``/``awayMode.coolTarget`` nested fields
+        via the matching ``set_away_*`` methods on pysensorlinx 0.5.3+.
+        On older pysensorlinx the away-routing branch falls back to
+        the home-mode writes (which the cloud silently ignores while
+        away is active — this matches pre-0.5.3 behaviour).
         """
         low = kwargs.get(ATTR_TARGET_TEMP_LOW)
         high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         temperature = kwargs.get(ATTR_TEMPERATURE)
 
         helper = self._device_helper()
+        away = self.preset_mode == _THM_PRESET_AWAY
         try:
             if low is not None and high is not None:
-                await helper.set_heat_cool_setpoints(
-                    Temperature(low, "F"),
-                    Temperature(high, "F"),
-                )
+                if away and hasattr(helper, "set_away_heat_cool_setpoints"):
+                    await helper.set_away_heat_cool_setpoints(
+                        Temperature(low, "F"),
+                        Temperature(high, "F"),
+                    )
+                else:
+                    await helper.set_heat_cool_setpoints(
+                        Temperature(low, "F"),
+                        Temperature(high, "F"),
+                    )
             elif temperature is not None:
                 mode = self.hvac_mode
                 if mode == HVACMode.COOL:
-                    await helper.set_cool_setpoint(Temperature(temperature, "F"))
+                    if away and hasattr(helper, "set_away_cool_setpoint"):
+                        await helper.set_away_cool_setpoint(
+                            Temperature(temperature, "F")
+                        )
+                    else:
+                        await helper.set_cool_setpoint(Temperature(temperature, "F"))
                 else:
                     # Default to heat for HEAT (and any unknown) — matches
                     # the HBX app's behaviour.
-                    await helper.set_heat_setpoint(Temperature(temperature, "F"))
+                    if away and hasattr(helper, "set_away_heat_setpoint"):
+                        await helper.set_away_heat_setpoint(
+                            Temperature(temperature, "F")
+                        )
+                    else:
+                        await helper.set_heat_setpoint(Temperature(temperature, "F"))
             else:
                 return
             await self.coordinator.async_request_refresh()

--- a/custom_components/hbx_controls/coordinator.py
+++ b/custom_components/hbx_controls/coordinator.py
@@ -208,6 +208,26 @@ async def _extract_thm_parameters(device_helper, device: dict) -> dict[str, Any]
     except Exception as exc:  # noqa: BLE001
         _LOGGER.debug("THM away mode: %s", exc)
 
+    # Away-mode setpoints — pysensorlinx 0.5.3+. The Away preset reads
+    # from a separate nested object (awayMode.heatTarget/coolTarget) and
+    # the home setpoints (rmT/rmCT) are silently ignored while away is
+    # active. Guarded with hasattr for older pysensorlinx versions.
+    if hasattr(device_helper, "get_away_heat_setpoint"):
+        try:
+            away_heat = await device_helper.get_away_heat_setpoint(device)
+            if away_heat is not None:
+                parameters["away_heat_setpoint"] = away_heat.value
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("THM away heat setpoint: %s", exc)
+
+    if hasattr(device_helper, "get_away_cool_setpoint"):
+        try:
+            away_cool = await device_helper.get_away_cool_setpoint(device)
+            if away_cool is not None:
+                parameters["away_cool_setpoint"] = away_cool.value
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("THM away cool setpoint: %s", exc)
+
     # Schedule + humidity raw fields. pysensorlinx 0.5.0 added setters
     # for these but no getters yet, so we read them straight from the
     # device dict. Field names confirmed from THM-0600 dumps 2026-04-28.

--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
-  "requirements": ["pysensorlinx==0.5.2"],
-  "version": "2.5.0b9"
+  "requirements": ["pysensorlinx==0.5.3"],
+  "version": "2.5.0b10"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b9"
+version = "2.5.0b10"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_thm_climate.py
+++ b/tests/test_thm_climate.py
@@ -236,6 +236,9 @@ def patched_thm():
         instance.set_heat_setpoint = AsyncMock()
         instance.set_cool_setpoint = AsyncMock()
         instance.set_heat_cool_setpoints = AsyncMock()
+        instance.set_away_heat_setpoint = AsyncMock()
+        instance.set_away_cool_setpoint = AsyncMock()
+        instance.set_away_heat_cool_setpoints = AsyncMock()
         cls.return_value = instance
         yield instance
 
@@ -338,3 +341,139 @@ async def test_write_swallows_setter_failure(thm_climate, patched_thm, caplog):
     thm_climate.coordinator.async_request_refresh = AsyncMock()
     await thm_climate.async_set_hvac_mode(HVACMode.HEAT)  # must not raise
     assert "Failed to set THM HVAC mode" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# 2.5.0b10: Away-preset setpoint routing
+#
+# When the Away preset is active the home setpoints (rmT/rmCT) are
+# silently ignored by the cloud. We route reads/writes to the
+# awayMode.heatTarget/coolTarget nested fields instead.
+# ---------------------------------------------------------------------------
+
+
+def test_target_temperature_high_uses_away_value_in_away_preset(mock_coordinator):
+    device = _coordinator_with_thm(
+        mock_coordinator,
+        hvac_mode="auto",
+        away_mode_activated=True,
+        away_heat_setpoint=58.0,
+        away_cool_setpoint=92.0,
+    )
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.target_temperature_low == 58.0
+    assert ent.target_temperature_high == 92.0
+
+
+def test_target_temperature_low_high_falls_back_to_home_when_away_missing(mock_coordinator):
+    """Older firmware / missing payload -> fall back to home setpoints."""
+    device = _coordinator_with_thm(
+        mock_coordinator,
+        hvac_mode="auto",
+        away_mode_activated=True,
+        # No away_heat_setpoint / away_cool_setpoint provided.
+    )
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.target_temperature_low == 70.0
+    assert ent.target_temperature_high == 78.0
+
+
+def test_target_temperature_uses_away_value_in_heat_when_away(mock_coordinator):
+    device = _coordinator_with_thm(
+        mock_coordinator,
+        hvac_mode="heat",
+        away_mode_activated=True,
+        away_heat_setpoint=58.0,
+        away_cool_setpoint=92.0,
+    )
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.target_temperature == 58.0
+
+
+def test_target_temperature_uses_away_value_in_cool_when_away(mock_coordinator):
+    device = _coordinator_with_thm(
+        mock_coordinator,
+        hvac_mode="cool",
+        away_mode_activated=True,
+        away_heat_setpoint=58.0,
+        away_cool_setpoint=92.0,
+    )
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.target_temperature == 92.0
+
+
+def test_target_temperature_low_high_uses_home_when_not_away(mock_coordinator):
+    device = _coordinator_with_thm(
+        mock_coordinator,
+        hvac_mode="auto",
+        away_mode_activated=False,
+        away_heat_setpoint=58.0,  # present but ignored -- home preset
+        away_cool_setpoint=92.0,
+    )
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    assert ent.target_temperature_low == 70.0
+    assert ent.target_temperature_high == 78.0
+
+
+async def test_async_set_temperature_heat_cool_routes_to_away(mock_coordinator, patched_thm):
+    """HEAT_COOL + Away preset -> set_away_heat_cool_setpoints."""
+    device = _coordinator_with_thm(
+        mock_coordinator, hvac_mode="auto", away_mode_activated=True,
+    )
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    ent.coordinator.async_request_refresh = AsyncMock()
+    await ent.async_set_temperature(**{
+        ATTR_TARGET_TEMP_LOW: 58,
+        ATTR_TARGET_TEMP_HIGH: 92,
+    })
+    patched_thm.set_away_heat_cool_setpoints.assert_awaited_once()
+    args = patched_thm.set_away_heat_cool_setpoints.await_args.args
+    assert args[0].to_fahrenheit() == 58
+    assert args[1].to_fahrenheit() == 92
+    # Must NOT have written to the home-mode setpoints.
+    patched_thm.set_heat_cool_setpoints.assert_not_awaited()
+    patched_thm.set_heat_setpoint.assert_not_awaited()
+    patched_thm.set_cool_setpoint.assert_not_awaited()
+
+
+async def test_async_set_temperature_heat_routes_to_away(mock_coordinator, patched_thm):
+    """HEAT + Away preset -> set_away_heat_setpoint."""
+    device = _coordinator_with_thm(
+        mock_coordinator, hvac_mode="heat", away_mode_activated=True,
+    )
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    ent.coordinator.async_request_refresh = AsyncMock()
+    await ent.async_set_temperature(**{ATTR_TEMPERATURE: 58})
+    patched_thm.set_away_heat_setpoint.assert_awaited_once()
+    temp = patched_thm.set_away_heat_setpoint.await_args.args[0]
+    assert temp.to_fahrenheit() == 58
+    patched_thm.set_heat_setpoint.assert_not_awaited()
+
+
+async def test_async_set_temperature_cool_routes_to_away(mock_coordinator, patched_thm):
+    """COOL + Away preset -> set_away_cool_setpoint."""
+    device = _coordinator_with_thm(
+        mock_coordinator, hvac_mode="cool", away_mode_activated=True,
+    )
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    ent.coordinator.async_request_refresh = AsyncMock()
+    await ent.async_set_temperature(**{ATTR_TEMPERATURE: 92})
+    patched_thm.set_away_cool_setpoint.assert_awaited_once()
+    temp = patched_thm.set_away_cool_setpoint.await_args.args[0]
+    assert temp.to_fahrenheit() == 92
+    patched_thm.set_cool_setpoint.assert_not_awaited()
+
+
+async def test_async_set_temperature_home_preset_uses_home_setters(mock_coordinator, patched_thm):
+    """Home preset writes still go to the home-mode setters (regression)."""
+    device = _coordinator_with_thm(
+        mock_coordinator, hvac_mode="auto", away_mode_activated=False,
+    )
+    ent = HBXControlsThmClimate(mock_coordinator, THM_DEVICE_ID, device)
+    ent.coordinator.async_request_refresh = AsyncMock()
+    await ent.async_set_temperature(**{
+        ATTR_TARGET_TEMP_LOW: 67,
+        ATTR_TARGET_TEMP_HIGH: 79,
+    })
+    patched_thm.set_heat_cool_setpoints.assert_awaited_once()
+    patched_thm.set_away_heat_cool_setpoints.assert_not_awaited()


### PR DESCRIPTION
## Summary

`2.5.0b10` follows up on b9 by routing both reads and writes to the **Away-preset setpoints** when the Away preset is active.

In b9 the dual-setpoint sliders worked from HA but the cloud silently ignored writes whenever the Away preset was active — the device kept reporting the away values from the HBX app's separate "away setpoints" popup. Eelton's paired before/after dumps from a live THM-0600 (2026-05-01) confirmed Away setpoints live in a different nested object: `awayMode.heatTarget.value` / `awayMode.coolTarget.value`.

Now bumped to `pysensorlinx==0.5.3`, which adds five new accessors for these nested fields.

## Changes

- **coordinator**: extract `away_heat_setpoint` and `away_cool_setpoint` via the new pysensorlinx getters (hasattr-guarded for older lib)
- **climate.target_temperature_low/high and target_temperature**: when Away preset is active **and** an away setpoint is published, return the away value so the HA UI matches what the device is actually targeting
- **climate.async_set_temperature**: when Away is active, route to `set_away_heat_cool_setpoints` / `set_away_heat_setpoint` / `set_away_cool_setpoint` instead of the home-mode setters

## Fallbacks

- Reads: if the away setpoint isn't published (older firmware / payload missing), fall back to the home setpoint
- Writes: if the helper is on pre-0.5.3 pysensorlinx (no `set_away_*` method), fall back to the home-mode setters — preserves prior b9 behaviour exactly

## Open question

The pysensorlinx 0.5.3 PATCH shape is partial-nested — `{"awayMode": {"heatTarget": {"value": 58}}}` — which we believe the cloud will deep-merge. If the live test (eelton again) shows it doesn't persist, we'll iterate to a full-block read-modify-write strategy in 0.5.4 / b11.

## Testing

- 9 new tests (read-side fallback, read-side away routing for HEAT/COOL/HEAT_COOL, write-side away routing, home-preset regression).
- Full suite: **415 passing** (was 406).

Closes nothing — keeps issue #12 open until eelton confirms the live device honors the Away PATCH.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
