### PR TITLE
chore: bump pysensorlinx to 0.5.4 (2.5.0b11)

### DIFF
--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
-  "requirements": ["pysensorlinx==0.5.3"],
-  "version": "2.5.0b10"
+  "requirements": ["pysensorlinx==0.5.4"],
+  "version": "2.5.0b11"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b10"
+version = "2.5.0b11"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## What

Bump pinned pysensorlinx to 0.5.4 and version to 2.5.0b11.

## Why

0.5.3 sent partial-nested awayMode PATCHes that the cloud silently dropped — HA writes to the away preset never propagated. 0.5.4 read-modify-writes the full block (matching what the HBX mobile app does). No integration-side code change required; b10's climate-side preset routing was already correct.

## Tests

415 passed (no test changes).
