### PR TITLE
chore: bump pysensorlinx to 0.5.5 (2.5.0b12)

### DIFF
--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
-  "requirements": ["pysensorlinx==0.5.4"],
-  "version": "2.5.0b11"
+  "requirements": ["pysensorlinx==0.5.5"],
+  "version": "2.5.0b12"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b11"
+version = "2.5.0b12"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## What

Bump pinned pysensorlinx to 0.5.5 (debug logging in the THM away-mode write path) and version to 2.5.0b12.

## Why

Diagnostic build. With debug logging enabled on the user's HA, one away-setpoint write attempt will surface the loaded awayMode block, the PATCH URL + body, and the cloud's response status — enough to distinguish "cloud silently 200s and drops" from "cloud actually rejects" and to spot any body-shape mismatch versus what the HBX app sends.

## Tests

415 passed.
