### PR TITLE
chore: 2.5.0b13 (pysensorlinx 0.5.6 away-setpoint hRmT/hRmCT fix)

### DIFF
--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
-  "requirements": ["pysensorlinx==0.5.5"],
-  "version": "2.5.0b12"
+  "requirements": ["pysensorlinx==0.5.6"],
+  "version": "2.5.0b13"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b12"
+version = "2.5.0b13"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
# 2.5.0b13: pysensorlinx 0.5.6 (away-setpoint `hRmT`/`hRmCT` fix)

Picks up pysensorlinx 0.5.6 — see [pysensorlinx#30](https://github.com/sslivins/pysensorlinx/pull/30) for the deep dive.

## TL;DR

The cloud's bulk device PATCH silently drops nested writes to
`awayMode.heatTarget.value` / `coolTarget.value` (returns 200,
ignores the change). The actual writable scalars are `hRmT` (heat) and
`hRmCT` (cool); the nested `awayMode.*.value` fields are read-only
mirrors used by the mobile app for display.

In b12 (eelton's debug logs):
- PATCH URL/body/response all captured cleanly
- Cloud returned `200 OK` for every away-setpoint write
- Server-side value never changed

In b13 / pysensorlinx 0.5.6:
- Flat scalar PATCH (`{"hRmT": 58}`) — same shape every other write in
  pysensorlinx already uses

## Validation

- Five paired before/after dumps from a live THM-0600 (2026-05-01) confirm
  `hRmT` / `hRmCT` track `awayMode.heatTarget.value` /
  `awayMode.coolTarget.value` exactly across every app-driven change.
- Local test suite: 415 passed.

## Changes

- `pyproject.toml` → `2.5.0b13`
- `manifest.json` → `2.5.0b13`, `pysensorlinx==0.5.6`

## Refs

- pysensorlinx#30 (the actual fix)
- issue #12 (eelton's away-setpoint write thread)
