### PR TITLE
release: 2.5.0

### DIFF
--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
   "requirements": ["pysensorlinx==0.5.6"],
-  "version": "2.5.0b13"
+  "version": "2.5.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-hbxcontrols"
-version = "2.5.0b13"
+version = "2.5.0"
 description = "Home Assistant custom integration for HBX Controls devices"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Graduates the 2.5.0bN beta line to a stable release. Pinned to pysensorlinx 0.5.6 with the away-setpoint `hRmT`/`hRmCT` fix verified end-to-end by @eelton in #12.

## Highlights since 2.4.x

- THM climate entity (heat / cool / auto / off, setpoint writes, fan mode, schedule, away)
- ZON climate entity
- AUTO mode dual setpoints (target_temp_low / target_temp_high)
- Away-mode setpoint writes (final fix in 2.5.0b13: cloud bulk PATCH silently dropped nested `awayMode` writes; switched to flat `hRmT`/`hRmCT` scalars — see pysensorlinx#30)
- Login resilience improvements (pysensorlinx 0.5.x)

## Tests

415 passed locally.
