### PR TITLE
Add integration_type 'hub' to manifest

### DIFF
--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -5,6 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/sslivins/hass_hbxcontrols",
+  "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
   "requirements": ["pysensorlinx==0.5.6"],


### PR DESCRIPTION
Required by the HACS default-list validator. HBX controllers expose many platforms (climate, water_heater, weather, sensor, binary_sensor, switch, number, select) from a single config entry, which fits `hub`.