### PR TITLE
Release 2.5.2

### DIFF
--- a/custom_components/hbx_controls/manifest.json
+++ b/custom_components/hbx_controls/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sslivins/hass_hbxcontrols/issues",
   "requirements": ["pysensorlinx==0.5.6"],
-  "version": "2.5.1"
+  "version": "2.5.2"
 }


### PR DESCRIPTION
Bump version to trigger a release that captures the `integration_type` addition from #41, in preparation for HACS default-list submission.